### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ A comprehensive Desktop Extension for searching Airbnb listings with advanced fi
 - **Rate limiting awareness** and respectful API usage
 - **Secure configuration** through DXT user settings
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/openbnb-org-mcp-server-airbnb).
+
 ## Installation
 
 ### For Claude Desktop


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/openbnb-org-mcp-server-airbnb).