### PR TITLE
Add airbnb_listing_reviews tool with keyword and tag filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ If you'd rather self-host the open-source server, read on.
 - **Property descriptions** and key features
 - **Direct links** to Airbnb listings for easy booking
 
+### 💬 Guest Reviews
+- **Full-text reviews** with reviewer name, date, language, and host responses
+- **Server-side keyword search** so agents can answer questions like "any reviews mentioning noise?" without scanning everything
+- **Tag filtering** by Airbnb's AI-generated review categories (Cleanliness, Location, Hospitality, etc.)
+- **Pagination** through listings with hundreds of reviews
+
 ### 🛡️ Security & Compliance
 - **Robots.txt compliance** with configurable override for testing
 - **Request timeout management** to prevent hanging requests
@@ -163,6 +169,25 @@ Get detailed information about a specific Airbnb listing.
   - House rules and policies
   - Property highlights and descriptions
   - Direct link to the listing
+
+### `airbnb_listing_reviews`
+
+Fetch guest reviews for a specific listing, with optional server-side keyword search and tag filtering.
+
+**Parameters:**
+- `id` (required): Airbnb listing ID
+- `query` (optional): Free-text keyword search across review content (e.g. `"noise"`, `"air conditioning"`, `"wifi"`). Multi-word queries supported. Matched terms are returned wrapped in `<mark>` tags inside `comments`. Combines with `tagName`. Note: Airbnb's search is literal — it won't match synonyms (e.g. `"noise"` will not match `"loud"`); for exhaustive scans, omit `query` and search the full reviews client-side.
+- `tagName` (optional): Filter to a single Airbnb-tagged category. Use the uppercase `name` from the `reviewTags` field of the response, e.g. `"CLEANLINESS"`, `"LOCATION"`, `"HOSPITALITY"`, `"WALKABILITY"`, `"PARKING"`, `"VIEW"`. Combines with `query`.
+- `limit` (optional): Maximum number of reviews to return. Omit to fetch all matching reviews (popular listings can have hundreds — token-heavy).
+- `offset` (optional): Number of reviews to skip before returning (default: 0). Use with `limit` for paging.
+- `sortingPreference` (optional): `MOST_RECENT` (default), `BEST_QUALITY`, `RATING_DESC`, or `RATING_ASC`. `MOST_RECENT` gives a fair cross-section; `BEST_QUALITY` is Airbnb's default and surfaces positive reviews first.
+- `ignoreRobotsText` (optional): Override robots.txt for this request
+
+**Returns:**
+- `total` — total review count for the listing (or filtered subset)
+- `returned` — number of reviews in this response
+- `reviewTags` — Airbnb's AI-generated category tags with counts (use the `name` for the `tagName` filter)
+- `reviews` — array of `{id, createdAt, language, reviewer, comments, hostResponse}`
 
 ## Technical Details
 

--- a/index.ts
+++ b/index.ts
@@ -142,7 +142,7 @@ const AIRBNB_LISTING_DETAILS_TOOL: Tool = {
 
 const AIRBNB_LISTING_REVIEWS_TOOL: Tool = {
   name: "airbnb_listing_reviews",
-  description: "Fetch guest reviews for a specific Airbnb listing. Returns the full text of each review so the agent can scan for keywords (e.g. 'noise', 'wifi', 'cleanliness'). Paginates Airbnb's reviews endpoint server-side and returns a flat list along with the total review count and Airbnb's AI-generated review tags.",
+  description: "Fetch guest reviews for a specific Airbnb listing. Returns the full text of each review along with Airbnb's AI-generated review tags. Supports server-side keyword search (query) and tag filtering (tagName) — prefer these over fetching everything on listings with many reviews. Matched terms are wrapped in <mark> tags in the comments field.",
   inputSchema: {
     type: "object",
     properties: {
@@ -150,13 +150,21 @@ const AIRBNB_LISTING_REVIEWS_TOOL: Tool = {
         type: "string",
         description: "The Airbnb listing ID"
       },
+      query: {
+        type: "string",
+        description: "Free-text keyword search across review content (e.g. 'noise', 'air conditioning', 'wifi'). Multi-word queries are supported. Returns only matching reviews with matched terms wrapped in <mark> tags. Combines with tagName."
+      },
+      tagName: {
+        type: "string",
+        description: "Filter to a single Airbnb-tagged category. Use the uppercase 'name' from the reviewTags response field, e.g. 'CLEANLINESS', 'LOCATION', 'HOSPITALITY', 'WALKABILITY', 'PARKING', 'VIEW'. Bogus names silently return zero results. Combines with query."
+      },
       limit: {
         type: "number",
-        description: "Maximum number of reviews to return. Omit to fetch all reviews on the listing (popular listings can have hundreds, which is token-heavy)."
+        description: "Maximum number of reviews to return. Omit to fetch all matching reviews (after filters)."
       },
       offset: {
         type: "number",
-        description: "Number of reviews to skip before returning. Defaults to 0. Use with limit for paging through large listings."
+        description: "Number of reviews to skip before returning. Defaults to 0. Use with limit for paging."
       },
       sortingPreference: {
         type: "string",
@@ -862,27 +870,29 @@ async function fetchReviewsPage(
   globalListingId: string,
   offset: number,
   limit: number,
-  sortingPreference: string
+  sortingPreference: string,
+  query?: string,
+  tagName?: string
 ): Promise<any> {
-  const variables = {
-    id: globalListingId,
-    pdpReviewsRequest: {
-      fieldSelector: "for_p3_translation_only",
-      forPreview: false,
-      limit,
-      offset: String(offset),
-      showingTranslationButton: false,
-      first: limit,
-      sortingPreference,
-      checkinDate: null,
-      checkoutDate: null,
-      numberOfAdults: "1",
-      numberOfChildren: "0",
-      numberOfInfants: "0",
-      numberOfPets: "0",
-      amenityFilters: null,
-    },
+  const pdpReviewsRequest: Record<string, any> = {
+    fieldSelector: "for_p3_translation_only",
+    forPreview: false,
+    limit,
+    offset: String(offset),
+    showingTranslationButton: false,
+    first: limit,
+    sortingPreference,
+    checkinDate: null,
+    checkoutDate: null,
+    numberOfAdults: "1",
+    numberOfChildren: "0",
+    numberOfInfants: "0",
+    numberOfPets: "0",
+    amenityFilters: null,
   };
+  if (query) pdpReviewsRequest.query = query;
+  if (tagName) pdpReviewsRequest.tagName = tagName;
+  const variables = { id: globalListingId, pdpReviewsRequest };
   const extensions = {
     persistedQuery: { version: 1, sha256Hash: STAYS_PDP_REVIEWS_QUERY_HASH },
   };
@@ -927,6 +937,8 @@ async function fetchReviewsPage(
 async function handleAirbnbListingReviews(params: any) {
   const {
     id,
+    query,
+    tagName,
     limit,
     offset = 0,
     sortingPreference = "MOST_RECENT",
@@ -965,7 +977,7 @@ async function handleAirbnbListingReviews(params: any) {
   const userLimit = limit !== undefined ? Math.max(0, parseInt(String(limit))) : undefined;
 
   try {
-    log("info", "Fetching listing reviews", { id, offset: startOffset, limit: userLimit, sortingPreference });
+    log("info", "Fetching listing reviews", { id, offset: startOffset, limit: userLimit, sortingPreference, query, tagName });
 
     const allReviews: any[] = [];
     let total: number | undefined;
@@ -977,7 +989,7 @@ async function handleAirbnbListingReviews(params: any) {
       if (remaining <= 0) break;
 
       const pageSize = Math.min(REVIEWS_PAGE_SIZE, remaining);
-      const json = await fetchReviewsPage(globalListingId, cursor, pageSize, sortingPreference);
+      const json = await fetchReviewsPage(globalListingId, cursor, pageSize, sortingPreference, query, tagName);
       const node = json?.data?.presentation?.stayProductDetailPage?.reviews;
       if (!node) {
         const errors = json?.errors;
@@ -1023,6 +1035,8 @@ async function handleAirbnbListingReviews(params: any) {
           returned: allReviews.length,
           offset: startOffset,
           sortingPreference,
+          query: query ?? null,
+          tagName: tagName ?? null,
           reviewTags,
           reviews: allReviews,
         }, null, 2)

--- a/index.ts
+++ b/index.ts
@@ -140,9 +140,42 @@ const AIRBNB_LISTING_DETAILS_TOOL: Tool = {
   }
 };
 
+const AIRBNB_LISTING_REVIEWS_TOOL: Tool = {
+  name: "airbnb_listing_reviews",
+  description: "Fetch guest reviews for a specific Airbnb listing. Returns the full text of each review so the agent can scan for keywords (e.g. 'noise', 'wifi', 'cleanliness'). Paginates Airbnb's reviews endpoint server-side and returns a flat list along with the total review count and Airbnb's AI-generated review tags.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      id: {
+        type: "string",
+        description: "The Airbnb listing ID"
+      },
+      limit: {
+        type: "number",
+        description: "Maximum number of reviews to return. Omit to fetch all reviews on the listing (popular listings can have hundreds, which is token-heavy)."
+      },
+      offset: {
+        type: "number",
+        description: "Number of reviews to skip before returning. Defaults to 0. Use with limit for paging through large listings."
+      },
+      sortingPreference: {
+        type: "string",
+        enum: ["MOST_RECENT", "BEST_QUALITY", "RATING_DESC", "RATING_ASC"],
+        description: "Sort order. Defaults to MOST_RECENT, which gives a fair cross-section. BEST_QUALITY is Airbnb's default and surfaces positive reviews first."
+      },
+      ignoreRobotsText: {
+        type: "boolean",
+        description: "Ignore robots.txt rules for this request"
+      }
+    },
+    required: ["id"]
+  }
+};
+
 const AIRBNB_TOOLS = [
   AIRBNB_SEARCH_TOOL,
   AIRBNB_LISTING_DETAILS_TOOL,
+  AIRBNB_LISTING_REVIEWS_TOOL,
 ] as const;
 
 // Utility functions
@@ -815,6 +848,207 @@ async function handleAirbnbListingDetails(params: any) {
   }
 }
 
+// Airbnb's public web client key, embedded in their JS bundle. Stable for years
+// but technically rotatable. The persisted-query hash below is more fragile —
+// Airbnb regenerates it on deploys that touch the GraphQL schema. If reviews
+// fetches start returning PersistedQueryNotFound we'll need to refresh it
+// (capture from a real listing page, same way we did originally).
+const AIRBNB_API_KEY = "d306zoyjsyarp7ifhu67rjxn52tv0t20";
+const STAYS_PDP_REVIEWS_QUERY_HASH =
+  "2ed951bfedf71b87d9d30e24a419e15517af9fbed7ac560a8d1cc7feadfa22e6";
+const REVIEWS_PAGE_SIZE = 50;
+
+async function fetchReviewsPage(
+  globalListingId: string,
+  offset: number,
+  limit: number,
+  sortingPreference: string
+): Promise<any> {
+  const variables = {
+    id: globalListingId,
+    pdpReviewsRequest: {
+      fieldSelector: "for_p3_translation_only",
+      forPreview: false,
+      limit,
+      offset: String(offset),
+      showingTranslationButton: false,
+      first: limit,
+      sortingPreference,
+      checkinDate: null,
+      checkoutDate: null,
+      numberOfAdults: "1",
+      numberOfChildren: "0",
+      numberOfInfants: "0",
+      numberOfPets: "0",
+      amenityFilters: null,
+    },
+  };
+  const extensions = {
+    persistedQuery: { version: 1, sha256Hash: STAYS_PDP_REVIEWS_QUERY_HASH },
+  };
+  const url = new URL(
+    `${BASE_URL}/api/v3/StaysPdpReviewsQuery/${STAYS_PDP_REVIEWS_QUERY_HASH}`
+  );
+  url.searchParams.set("operationName", "StaysPdpReviewsQuery");
+  url.searchParams.set("locale", "en");
+  url.searchParams.set("currency", "USD");
+  url.searchParams.set("variables", JSON.stringify(variables));
+  url.searchParams.set("extensions", JSON.stringify(extensions));
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 30000);
+  try {
+    const response = await fetch(url.toString(), {
+      headers: {
+        "User-Agent": USER_AGENT,
+        "Accept": "*/*",
+        "Accept-Language": "en-US,en;q=0.9",
+        "X-Airbnb-API-Key": AIRBNB_API_KEY,
+        "X-Airbnb-GraphQL-Platform": "web",
+        "X-Airbnb-GraphQL-Platform-Client": "minimalist-niobe",
+        "X-CSRF-Without-Token": "1",
+      },
+      signal: controller.signal,
+    });
+    clearTimeout(timeoutId);
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+    }
+    return await response.json();
+  } catch (error) {
+    clearTimeout(timeoutId);
+    if (error instanceof Error && error.name === "AbortError") {
+      throw new Error("Reviews request timeout after 30000ms");
+    }
+    throw error;
+  }
+}
+
+async function handleAirbnbListingReviews(params: any) {
+  const {
+    id,
+    limit,
+    offset = 0,
+    sortingPreference = "MOST_RECENT",
+    ignoreRobotsText = false,
+  } = params;
+
+  if (!id) {
+    return {
+      content: [{
+        type: "text",
+        text: JSON.stringify({ error: "Missing required parameter: id" }, null, 2)
+      }],
+      isError: true
+    };
+  }
+
+  const listingUrl = new URL(`${BASE_URL}/rooms/${id}`);
+  const path = listingUrl.pathname + listingUrl.search;
+  if (!ignoreRobotsText && !isPathAllowed(path)) {
+    log("warn", "Listing reviews blocked by robots.txt", { path, url: listingUrl.toString() });
+    return {
+      content: [{
+        type: "text",
+        text: JSON.stringify({
+          error: robotsErrorMessage,
+          url: listingUrl.toString(),
+          suggestion: "Consider enabling 'ignore_robots_txt' in extension settings if needed for testing"
+        }, null, 2)
+      }],
+      isError: true
+    };
+  }
+
+  const globalListingId = Buffer.from(`StayListing:${id}`).toString("base64");
+  const startOffset = Math.max(0, parseInt(String(offset))) || 0;
+  const userLimit = limit !== undefined ? Math.max(0, parseInt(String(limit))) : undefined;
+
+  try {
+    log("info", "Fetching listing reviews", { id, offset: startOffset, limit: userLimit, sortingPreference });
+
+    const allReviews: any[] = [];
+    let total: number | undefined;
+    let reviewTags: any[] = [];
+    let cursor = startOffset;
+
+    while (true) {
+      const remaining = userLimit !== undefined ? userLimit - allReviews.length : Infinity;
+      if (remaining <= 0) break;
+
+      const pageSize = Math.min(REVIEWS_PAGE_SIZE, remaining);
+      const json = await fetchReviewsPage(globalListingId, cursor, pageSize, sortingPreference);
+      const node = json?.data?.presentation?.stayProductDetailPage?.reviews;
+      if (!node) {
+        const errors = json?.errors;
+        throw new Error(
+          `Unexpected reviews response shape${errors ? `: ${JSON.stringify(errors).slice(0, 200)}` : ""}`
+        );
+      }
+
+      if (total === undefined) {
+        total = node.metadata?.reviewsCount ?? 0;
+        reviewTags = (node.metadata?.reviewTags ?? []).map((t: any) => ({
+          name: t.name,
+          localizedName: t.localizedName,
+          count: t.count,
+        }));
+      }
+
+      const batch = node.reviews ?? [];
+      for (const r of batch) {
+        allReviews.push({
+          id: r.id,
+          createdAt: r.createdAt,
+          language: r.language,
+          reviewer: r.reviewer?.firstName,
+          comments: r.comments,
+          hostResponse: r.responder?.response ?? r.response ?? null,
+        });
+      }
+
+      if (batch.length < pageSize) break;
+      cursor += batch.length;
+      if (total !== undefined && cursor >= total) break;
+    }
+
+    log("info", "Listing reviews fetched", { id, returned: allReviews.length, total });
+
+    return {
+      content: [{
+        type: "text",
+        text: JSON.stringify({
+          listingUrl: listingUrl.toString(),
+          total: total ?? allReviews.length,
+          returned: allReviews.length,
+          offset: startOffset,
+          sortingPreference,
+          reviewTags,
+          reviews: allReviews,
+        }, null, 2)
+      }],
+      isError: false
+    };
+  } catch (error) {
+    log("error", "Listing reviews request failed", {
+      error: error instanceof Error ? error.message : String(error),
+      id,
+    });
+    return {
+      content: [{
+        type: "text",
+        text: JSON.stringify({
+          error: error instanceof Error ? error.message : String(error),
+          listingUrl: listingUrl.toString(),
+          hint: "If the error mentions PersistedQueryNotFound, Airbnb has rotated the StaysPdpReviewsQuery hash. Capture the new one from a listing page and update STAYS_PDP_REVIEWS_QUERY_HASH.",
+          timestamp: new Date().toISOString(),
+        }, null, 2)
+      }],
+      isError: true
+    };
+  }
+}
+
 // Server setup
 const server = new Server(
   {
@@ -885,6 +1119,11 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
       case "airbnb_listing_details": {
         result = await handleAirbnbListingDetails(request.params.arguments);
+        break;
+      }
+
+      case "airbnb_listing_reviews": {
+        result = await handleAirbnbListingReviews(request.params.arguments);
         break;
       }
 

--- a/manifest.json
+++ b/manifest.json
@@ -47,6 +47,10 @@
     {
       "name": "airbnb_listing_details",
       "description": "Get detailed information about a specific Airbnb listing including amenities, policies, location details, and highlights."
+    },
+    {
+      "name": "airbnb_listing_reviews",
+      "description": "Fetch guest reviews for a specific Airbnb listing. Returns the full review text plus Airbnb's AI-generated review tags so an agent can scan for keywords like 'noise', 'wifi', or 'cleanliness'. Supports limit/offset paging."
     }
   ],
   "tools_generated": false,

--- a/manifest.json
+++ b/manifest.json
@@ -50,7 +50,7 @@
     },
     {
       "name": "airbnb_listing_reviews",
-      "description": "Fetch guest reviews for a specific Airbnb listing. Returns the full review text plus Airbnb's AI-generated review tags so an agent can scan for keywords like 'noise', 'wifi', or 'cleanliness'. Supports limit/offset paging."
+      "description": "Fetch guest reviews for a specific Airbnb listing. Returns the full review text plus Airbnb's AI-generated review tags. Supports server-side keyword search (query) and tag filtering (tagName) so agents can drill into specific concerns like 'noise' or 'cleanliness' without paging through hundreds of reviews."
     }
   ],
   "tools_generated": false,


### PR DESCRIPTION
### Summary

Adds a new `airbnb_listing_reviews` MCP tool that fetches guest reviews for a listing, with optional server-side keyword search and tag filtering. Lets agents answer questions like "are there any reviews mentioning noise?" without paging through hundreds of reviews.

Aware of #19, which also adds reviews support via a different approach. Happy to defer to that one if you prefer it; this PR is structured to be reasonably small (~270 lines) and follow the same patterns as the existing search and listing-details tools.

### What changed

**New tool: `airbnb_listing_reviews`**
- Calls Airbnb's `StaysPdpReviewsQuery` persisted GraphQL endpoint (the same one the "Show all reviews" modal uses).
- Parameters: `id` (required), `query`, `tagName`, `limit`, `offset`, `sortingPreference`, `ignoreRobotsText`.
- `query` is free-text keyword search (e.g. `"noise"`, `"air conditioning"`). Multi-word supported. Matched terms are returned wrapped in `<mark>` tags.
- `tagName` filters to one of Airbnb's AI-generated categories (e.g. `CLEANLINESS`, `LOCATION`, `HOSPITALITY`). Combines with `query`.
- Response: `total`, `returned`, `reviewTags` (the AI category list with counts), and a flat `reviews` array (`id`, `createdAt`, `language`, `reviewer`, `comments`, `hostResponse`).
- Paginates until exhausted (server caps at 50 per request); `limit` lets callers cap output for token-heavy listings.
- Robots.txt gate matches the existing tools (checks `/rooms/<id>`, opt-out via `ignoreRobotsText` per call or `IGNORE_ROBOTS_TXT` env).

**Manifest:**
- Adds the tool entry to `manifest.json` so the MCPB bundle exposes it.

### Implementation notes

- The API key (`d306zoyjsyarp7ifhu67rjxn52tv0t20`) is Airbnb's public web client key, embedded in the JS bundle on every listing page and stable for years. Hardcoded as a constant.
- The persisted-query sha256 hash is also hardcoded. Same fragility profile as the existing `#data-deferred-state-0` selector — when Airbnb rotates it on a deploy, the tool returns a clear `PersistedQueryNotFound`-style error with a hint pointing at the constant to update.
- Airbnb's `query` filter is literal — no synonym expansion (`noise` won't match `loud`/`noisy`). The tool description notes this so agents know when to fall back to fetching all reviews and scanning client-side.

### Testing

Tested end-to-end via the MCP stdio protocol against listings with 70 and 102 reviews:
- Default fetch returns all reviews paginated correctly.
- `query` returns server-filtered subsets with `<mark>` highlighting.
- `tagName` totals match the per-tag counts in `metadata.reviewTags`.
- `query` + `tagName` returns the intersection.
- Bogus tag silently returns 0; bad listing ID returns a clean error.