### PR TITLE
Add server-side filters to airbnb_search

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ If you'd rather self-host the open-source server, read on.
 - **International location support** via client-side geocoding, so non-US queries (e.g. "Paris, France", "Copenhagen, Denmark") return results in the right city
 - **Google Maps Place ID** integration for precise location targeting
 - **Property type filtering** for entire homes, private rooms, shared rooms, or hotel rooms
+- **Amenity filtering** including Wifi, A/C, kitchen, washer, free parking, pool, hot tub, king bed, and self check-in
+- **Quality and booking filters** including Guest Favorite (Airbnb's curated bucket) and Instant Book
+- **Minimum bedroom/bed/bathroom counts** for sizing requirements
+- **Manual bounding-box override** to skip the third-party geocoder when you already have map coordinates
 - **Date filtering** with check-in and check-out date support
 - **Guest configuration** including adults, children, infants, and pets
 - **Price range filtering** with minimum and maximum price constraints
@@ -135,6 +139,13 @@ Search for Airbnb listings with comprehensive filtering options.
 - `maxPrice` (optional): Maximum price per night
 - `cursor` (optional): Pagination cursor for browsing results
 - `propertyType` (optional): Filter by property type — `entire_home`, `private_room`, `shared_room`, or `hotel_room`
+- `amenities` (optional): Array of amenity names to require. Supported values: `wifi`, `air_conditioning`, `washer`, `kitchen`, `free_parking`, `pool`, `hot_tub`, `king_bed`, `self_checkin`. King bed is an amenity in Airbnb's filter modal, not a separate bed-type filter.
+- `instantBook` (optional): Filter to listings with Instant Book enabled (no host approval needed)
+- `guestFavorite` (optional): Filter to Airbnb's curated "Guest favorite" quality bucket
+- `minBedrooms` (optional): Minimum number of bedrooms
+- `minBeds` (optional): Minimum number of beds (any type — to filter by type use `amenities`)
+- `minBathrooms` (optional): Minimum number of bathrooms
+- `ne_lat`, `ne_lng`, `sw_lat`, `sw_lng` (optional): Manual bounding-box corners. Provide all four together to override the geocoded bbox and skip the third-party geocoder entirely for this request.
 - `ignoreRobotsText` (optional): Override robots.txt for this request
 
 **Returns:**

--- a/index.ts
+++ b/index.ts
@@ -88,6 +88,50 @@ const AIRBNB_SEARCH_TOOL: Tool = {
         enum: ["entire_home", "private_room", "shared_room", "hotel_room"],
         description: "Filter by property type: 'entire_home' (entire homes/apartments), 'private_room' (private rooms in shared homes), 'shared_room' (shared/dorm-style rooms), 'hotel_room' (hotel rooms)"
       },
+      amenities: {
+        type: "array",
+        items: {
+          type: "string",
+          enum: ["wifi", "air_conditioning", "washer", "kitchen", "free_parking", "pool", "hot_tub", "king_bed", "self_checkin"]
+        },
+        description: "Filter to listings that have all of these amenities. 'king_bed' lives in Airbnb's amenities list (not a separate bed-type filter)."
+      },
+      instantBook: {
+        type: "boolean",
+        description: "Filter to listings with Instant Book enabled (no host approval needed)."
+      },
+      guestFavorite: {
+        type: "boolean",
+        description: "Filter to Airbnb's curated 'Guest favorite' quality bucket."
+      },
+      minBedrooms: {
+        type: "number",
+        description: "Minimum number of bedrooms."
+      },
+      minBeds: {
+        type: "number",
+        description: "Minimum number of beds (any type — to filter by type use amenities, e.g. ['king_bed'])."
+      },
+      minBathrooms: {
+        type: "number",
+        description: "Minimum number of bathrooms."
+      },
+      ne_lat: {
+        type: "number",
+        description: "Manual bounding-box override: northeast latitude. Provide all four bbox values together (ne_lat, ne_lng, sw_lat, sw_lng) to skip the third-party geocoder for this request."
+      },
+      ne_lng: {
+        type: "number",
+        description: "Manual bounding-box override: northeast longitude. See ne_lat."
+      },
+      sw_lat: {
+        type: "number",
+        description: "Manual bounding-box override: southwest latitude. See ne_lat."
+      },
+      sw_lng: {
+        type: "number",
+        description: "Manual bounding-box override: southwest longitude. See ne_lat."
+      },
       ignoreRobotsText: {
         type: "boolean",
         description: "Ignore robots.txt rules for this request"
@@ -294,6 +338,21 @@ const PROPERTY_TYPE_IDS: Record<string, string> = {
   hotel_room:   "4",
 };
 
+// Map canonical amenity names to Airbnb's internal numeric IDs.
+// Discovered by toggling each filter in the search modal and reading the URL —
+// Airbnb encodes selections as `amenities[]=<id>`. Add new entries here as needed.
+const AMENITY_IDS: Record<string, number> = {
+  wifi:             4,
+  air_conditioning: 5,
+  pool:             7,
+  kitchen:          8,
+  free_parking:     9,
+  hot_tub:          25,
+  washer:           33,
+  self_checkin:     51,
+  king_bed:         1000,
+};
+
 // Configuration from environment variables (set by DXT host)
 const IGNORE_ROBOTS_TXT = process.env.IGNORE_ROBOTS_TXT === "true" || process.argv.slice(2).includes("--ignore-robots-txt");
 // When true, skip the Photon/Nominatim geocoding step and let Airbnb's own
@@ -413,6 +472,16 @@ async function handleAirbnbSearch(params: any) {
     maxPrice,
     cursor,
     propertyType,
+    amenities,
+    instantBook,
+    guestFavorite,
+    minBedrooms,
+    minBeds,
+    minBathrooms,
+    ne_lat,
+    ne_lng,
+    sw_lat,
+    sw_lng,
     ignoreRobotsText = false,
   } = params;
 
@@ -427,11 +496,21 @@ async function handleAirbnbSearch(params: any) {
   
   // Add placeId
   if (placeId) searchUrl.searchParams.append("place_id", placeId);
-  
+
+  // Manual bounding-box override: agent supplied all four corners directly.
+  const manualBbox =
+    ne_lat != null && ne_lng != null && sw_lat != null && sw_lng != null;
+  if (manualBbox) {
+    searchUrl.searchParams.append("ne_lat", String(ne_lat));
+    searchUrl.searchParams.append("ne_lng", String(ne_lng));
+    searchUrl.searchParams.append("sw_lat", String(sw_lat));
+    searchUrl.searchParams.append("sw_lng", String(sw_lng));
+  }
+
   // Geocode and add bounding box to fix broken server-side geocoding.
-  // Skipped when placeId is supplied (Airbnb's place lookup is reliable for those)
-  // or when DISABLE_GEOCODING=true (user opt-out from third-party calls).
-  if (!placeId && !DISABLE_GEOCODING) {
+  // Skipped when placeId is supplied (Airbnb's place lookup is reliable for those),
+  // when a manual bbox was supplied, or when DISABLE_GEOCODING=true.
+  if (!placeId && !manualBbox && !DISABLE_GEOCODING) {
     const coords = await geocodeLocation(location);
     if (coords) {
       searchUrl.searchParams.append("ne_lat", coords.ne_lat);
@@ -467,6 +546,27 @@ async function handleAirbnbSearch(params: any) {
   if (propertyType && PROPERTY_TYPE_IDS[propertyType]) {
     searchUrl.searchParams.append("l2_property_type_ids[]", PROPERTY_TYPE_IDS[propertyType]);
   }
+
+  // Add amenity filters
+  if (Array.isArray(amenities)) {
+    for (const name of amenities) {
+      const id = AMENITY_IDS[name];
+      if (id != null) {
+        searchUrl.searchParams.append("amenities[]", String(id));
+      } else {
+        log("warn", "Unknown amenity name, skipping", { name });
+      }
+    }
+  }
+
+  // Quality / booking filters
+  if (instantBook) searchUrl.searchParams.append("ib", "true");
+  if (guestFavorite) searchUrl.searchParams.append("guest_favorite", "true");
+
+  // Minimum room/bed counts
+  if (minBedrooms != null) searchUrl.searchParams.append("min_bedrooms", String(minBedrooms));
+  if (minBeds != null) searchUrl.searchParams.append("min_beds", String(minBeds));
+  if (minBathrooms != null) searchUrl.searchParams.append("min_bathrooms", String(minBathrooms));
 
   // Add cursor for pagination
   if (cursor) {


### PR DESCRIPTION
### Summary

Adds server-side filter parameters to `airbnb_search` for the filters Airbnb's UI exposes but the tool didn't pass through. Lets agents narrow searches by amenities, quality flags, and minimum room counts before the response is returned, which matters on popular destinations where the unfiltered set is hundreds of listings.

### What changed

**New `airbnb_search` parameters:**
- `amenities` — typed enum array. Supported values: `wifi`, `air_conditioning`, `washer`, `kitchen`, `free_parking`, `pool`, `hot_tub`, `king_bed`, `self_checkin`. Mapped internally to Airbnb's numeric IDs (e.g. `amenities[]=4`).
- `instantBook` — boolean → `ib=true`
- `guestFavorite` — boolean → `guest_favorite=true`
- `minBedrooms`, `minBeds`, `minBathrooms` — numbers → `min_*`
- `ne_lat`, `ne_lng`, `sw_lat`, `sw_lng` — numbers. Manual bounding-box override; suppresses the Photon/Nominatim geocoder for that request when all four are supplied (useful when the agent already has map coordinates).

**README:**
- Adds Features bullets and parameter documentation for the new fields.

### Implementation notes

- Amenity name → numeric ID mapping lives in a constants table (`AMENITY_IDS`), discovered by toggling each filter in Airbnb's "All filters" modal and reading the URL. New amenities can be added with one line — same recon technique as future-proofing.
- King bed lives under "Amenities → Features" in Airbnb's modal (not under "Rooms and beds"), so it's exposed via `amenities: ["king_bed"]` rather than a separate bed-type filter. Documented in the parameter description.
- "Allows pets" isn't added as a separate filter parameter because the existing `pets >= 1` parameter already filters for pet-friendly listings (Airbnb encodes both as `pets=N`).
- Superhost is no longer a top-level filter in Airbnb's current UI, so it's not exposed.
- Unknown amenity names log a warning and are dropped silently rather than failing the request — typo-tolerant.

### Testing

End-to-end via the MCP stdio protocol against `Lisbon, Portugal`:
- Each filter sends the expected URL params (amenities map to correct IDs, booleans to the right flags, etc.).
- Manual bbox correctly suppresses the third-party geocoder.
- Unknown amenity warns + drops silently while valid amenities still attach.
- **Real result inventory changes as expected** (page 1, top-5 listing IDs vs unfiltered baseline):
  - `amenities: ["king_bed"]` → 0/5 overlap (completely different inventory)
  - `minBedrooms: 4` → 0/5 overlap (small-bedroom places filtered out)
  - `guestFavorite: true` → 4/5 overlap (clean subset of baseline, as expected for a curated bucket)
  - `instantBook: true` → 1/5 overlap (partial subset)