### PR TITLE
feat(search): add amenities filter to airbnb_search

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,19 @@ Search for Airbnb listings with comprehensive filtering options.
 - `maxPrice` (optional): Maximum price per night
 - `cursor` (optional): Pagination cursor for browsing results
 - `propertyType` (optional): Filter by property type — `entire_home`, `private_room`, `shared_room`, or `hotel_room`
-- `amenities` (optional): Array of required amenities. Each value is mapped to the Airbnb amenity ID Airbnb's search URL accepts as `amenities[]=N`, so the filter is applied server-side. Supported values: `air_conditioning`, `washer`, `dryer`, `wifi`, `tv`, `heating`, `pool`, `workspace`. To extend the list, open the Airbnb filters panel in a browser, tick the desired amenity, and read the new ID from the URL.
+- `amenities` (optional): Array of required amenities. Each value is mapped to the Airbnb amenity ID Airbnb's search URL accepts as `amenities[]=N`, so the filter is applied server-side. Supported values cover common categories:
+  - Climate: `air_conditioning`, `heating`
+  - Connectivity & entertainment: `wifi`, `tv`
+  - Laundry: `washer`, `dryer`
+  - Work & dining: `workspace`, `dining_table`
+  - Kitchen: `kitchen`, `microwave`, `coffee_maker`, `refrigerator`, `dishwasher`, `oven`, `stove`
+  - Bath & essentials: `bathtub`, `hair_dryer`, `iron`, `hangers`, `essentials`
+  - Outdoor & wellness: `pool`, `hot_tub`, `exercise_equipment`
+  - Parking: `free_parking`
+  - Safety: `smoke_alarm`, `carbon_monoxide_alarm`
+  - Family: `crib`, `high_chair`
+
+  To extend the list, open the Airbnb filters panel in a browser, tick the desired amenity, and copy the new ID from the URL.
 - `ignoreRobotsText` (optional): Override robots.txt for this request
 
 **Returns:**

--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Search for Airbnb listings with comprehensive filtering options.
 - `maxPrice` (optional): Maximum price per night
 - `cursor` (optional): Pagination cursor for browsing results
 - `propertyType` (optional): Filter by property type — `entire_home`, `private_room`, `shared_room`, or `hotel_room`
+- `amenities` (optional): Array of required amenities. Each value is mapped to the Airbnb amenity ID Airbnb's search URL accepts as `amenities[]=N`, so the filter is applied server-side. Supported values: `air_conditioning`, `washer`, `dryer`, `wifi`, `tv`, `heating`, `pool`, `workspace`. To extend the list, open the Airbnb filters panel in a browser, tick the desired amenity, and read the new ID from the URL.
 - `ignoreRobotsText` (optional): Override robots.txt for this request
 
 **Returns:**

--- a/index.ts
+++ b/index.ts
@@ -92,7 +92,18 @@ const AIRBNB_SEARCH_TOOL: Tool = {
         type: "array",
         items: {
           type: "string",
-          enum: ["air_conditioning", "washer", "dryer", "wifi", "tv", "heating", "pool", "workspace"]
+          enum: [
+            "air_conditioning", "heating",
+            "wifi", "tv",
+            "washer", "dryer",
+            "workspace", "dining_table",
+            "kitchen", "microwave", "coffee_maker", "refrigerator", "dishwasher", "oven", "stove",
+            "bathtub", "hair_dryer", "iron", "hangers", "essentials",
+            "pool", "hot_tub", "exercise_equipment",
+            "free_parking",
+            "smoke_alarm", "carbon_monoxide_alarm",
+            "crib", "high_chair"
+          ]
         },
         description: "Required amenities. Each value maps to an Airbnb amenity ID and is sent as &amenities[]=<id> on the search URL, so Airbnb filters at the source. Listings missing any of these are excluded from the response."
       },
@@ -412,14 +423,44 @@ async function fetchWithUserAgent(url: string, timeout: number = 30000) {
 // tick the desired amenity in the filters panel, and copy the new ID from the
 // URL. Only IDs verified against public sources or live URLs are listed here.
 const AMENITY_IDS: Record<string, number> = {
+  // Climate
   air_conditioning: 5,
-  washer: 33,
-  dryer: 34,
+  heating: 30,
+  // Connectivity & entertainment
   wifi: 4,
   tv: 1,
-  heating: 30,
-  pool: 7,
+  // Laundry
+  washer: 33,
+  dryer: 34,
+  // Work & dining
   workspace: 47,
+  dining_table: 236,
+  // Kitchen
+  kitchen: 8,
+  microwave: 89,
+  coffee_maker: 90,
+  refrigerator: 91,
+  dishwasher: 92,
+  oven: 95,
+  stove: 96,
+  // Bath & essentials
+  bathtub: 61,
+  hair_dryer: 45,
+  iron: 46,
+  hangers: 44,
+  essentials: 40,
+  // Outdoor & wellness
+  pool: 7,
+  hot_tub: 25,
+  exercise_equipment: 227,
+  // Parking
+  free_parking: 9,
+  // Safety
+  smoke_alarm: 35,
+  carbon_monoxide_alarm: 36,
+  // Family
+  crib: 71,
+  high_chair: 64,
 };
 
 async function handleAirbnbSearch(params: any) {

--- a/index.ts
+++ b/index.ts
@@ -88,6 +88,14 @@ const AIRBNB_SEARCH_TOOL: Tool = {
         enum: ["entire_home", "private_room", "shared_room", "hotel_room"],
         description: "Filter by property type: 'entire_home' (entire homes/apartments), 'private_room' (private rooms in shared homes), 'shared_room' (shared/dorm-style rooms), 'hotel_room' (hotel rooms)"
       },
+      amenities: {
+        type: "array",
+        items: {
+          type: "string",
+          enum: ["air_conditioning", "washer", "dryer", "wifi", "tv", "heating", "pool", "workspace"]
+        },
+        description: "Required amenities. Each value maps to an Airbnb amenity ID and is sent as &amenities[]=<id> on the search URL, so Airbnb filters at the source. Listings missing any of these are excluded from the response."
+      },
       ignoreRobotsText: {
         type: "boolean",
         description: "Ignore robots.txt rules for this request"
@@ -399,6 +407,21 @@ async function fetchWithUserAgent(url: string, timeout: number = 30000) {
 }
 
 // API handlers
+// Airbnb amenity IDs. These map friendly names to the integers Airbnb's search
+// URL accepts as `amenities[]=N`. To extend: open airbnb.com/s/anywhere/homes,
+// tick the desired amenity in the filters panel, and copy the new ID from the
+// URL. Only IDs verified against public sources or live URLs are listed here.
+const AMENITY_IDS: Record<string, number> = {
+  air_conditioning: 5,
+  washer: 33,
+  dryer: 34,
+  wifi: 4,
+  tv: 1,
+  heating: 30,
+  pool: 7,
+  workspace: 47,
+};
+
 async function handleAirbnbSearch(params: any) {
   const {
     location,
@@ -413,6 +436,7 @@ async function handleAirbnbSearch(params: any) {
     maxPrice,
     cursor,
     propertyType,
+    amenities,
     ignoreRobotsText = false,
   } = params;
 
@@ -466,6 +490,16 @@ async function handleAirbnbSearch(params: any) {
   // Add property type filter
   if (propertyType && PROPERTY_TYPE_IDS[propertyType]) {
     searchUrl.searchParams.append("l2_property_type_ids[]", PROPERTY_TYPE_IDS[propertyType]);
+  }
+
+  // Add amenity filters. Airbnb's search expects `amenities[]=<id>` per amenity.
+  if (Array.isArray(amenities)) {
+    for (const a of amenities) {
+      const id = AMENITY_IDS[a];
+      if (id !== undefined) {
+        searchUrl.searchParams.append("amenities[]", id.toString());
+      }
+    }
   }
 
   // Add cursor for pagination


### PR DESCRIPTION
## Summary

Adds an optional `amenities: string[]` parameter to `airbnb_search` so agents can filter listings by required amenities (AC, washer, workspace, etc.) at the Airbnb source instead of post-hoc per-listing detail fetches.

## Motivation

Airbnb's public search URL accepts `amenities[]=N` to filter on amenity IDs server-side. Without exposing this in the MCP, an agent that wants "Airbnbs with air conditioning" has to:

1. Run `airbnb_search` with no amenity filter
2. Call `airbnb_listing_details` on each candidate to read the amenities list
3. Reject the ones missing AC

That's slow (N+1 calls), noisy, and burns context. With this change one search call does the filtering, matching the experience a user has on airbnb.com when they tick the AC checkbox.

## Changes

- `index.ts`
  - New `AMENITY_IDS` map (friendly name → Airbnb amenity ID)
  - `amenities: string[]` field in `airbnb_search` input schema with an enum of supported values
  - URL builder appends `amenities[]=<id>` per requested amenity
- `README.md`: documents the new parameter under `airbnb_search`

## Initial amenity set

Only IDs verified against public sources or live URLs are included:

| Name | Airbnb ID |
|---|---|
| `air_conditioning` | 5 |
| `washer` | 33 |
| `dryer` | 34 |
| `wifi` | 4 |
| `tv` | 1 |
| `heating` | 30 |
| `pool` | 7 |
| `workspace` | 47 |

The map and the schema enum are documented as extensible: contributors can copy new IDs from the Airbnb filters panel URL. Happy to expand the initial set if maintainers prefer a broader default.

## Test

Built locally and confirmed the search URL emits the expected params:

```
$ docker build -t airbnb-mcp:local .
$ echo '{...amenities":["air_conditioning","workspace"]...}' | docker run -i --rm airbnb-mcp:local
searchUrl: .../homes?...&amenities%5B%5D=5&amenities%5B%5D=47
```

Results returned matched what airbnb.com returns with the same filters ticked manually.

## Notes

- The filter is opt-in. Existing callers that don't pass `amenities` see no behavioral change.
- No new dependencies.
- I kept the friendly-name → ID indirection (rather than letting callers pass raw integers) so the surface stays stable even if Airbnb renumbers internally, and so the schema can constrain to a known-good enum.