### PR TITLE
fix(search): correct propertyType filter URL parameter

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -287,11 +287,16 @@ async function geocodeLocation(location: string): Promise<{
   return coords;
 }
 
-const PROPERTY_TYPE_IDS: Record<string, string> = {
-  entire_home:  "1",
-  private_room: "2",
-  shared_room:  "3",
-  hotel_room:   "4",
+// Airbnb's room type filter on the public search URL. The previous mapping
+// used `l2_property_type_ids[]=N`, which is the subtype filter (Apartment,
+// House, Villa, etc.) and does NOT exclude shared/private rooms, so listings
+// like "Room in a home" leaked through when `entire_home` was requested. The
+// correct filter is `room_types[]=<label>` with the URL-encoded room type.
+const ROOM_TYPE_LABELS: Record<string, string> = {
+  entire_home:  "Entire home/apt",
+  private_room: "Private room",
+  shared_room:  "Shared room",
+  hotel_room:   "Hotel room",
 };
 
 // Configuration from environment variables (set by DXT host)
@@ -463,9 +468,9 @@ async function handleAirbnbSearch(params: any) {
   if (minPrice != null) searchUrl.searchParams.append("price_min", minPrice.toString());
   if (maxPrice != null) searchUrl.searchParams.append("price_max", maxPrice.toString());
   
-  // Add property type filter
-  if (propertyType && PROPERTY_TYPE_IDS[propertyType]) {
-    searchUrl.searchParams.append("l2_property_type_ids[]", PROPERTY_TYPE_IDS[propertyType]);
+  // Add room type filter (Entire / Private / Shared / Hotel room)
+  if (propertyType && ROOM_TYPE_LABELS[propertyType]) {
+    searchUrl.searchParams.append("room_types[]", ROOM_TYPE_LABELS[propertyType]);
   }
 
   // Add cursor for pagination


### PR DESCRIPTION
## Summary

`airbnb_search`'s `propertyType` argument is documented to filter results to entire homes, private rooms, shared rooms, or hotel rooms. In practice the filter has no effect, because the implementation sends the wrong URL parameter.

## The bug

```ts
const PROPERTY_TYPE_IDS: Record<string, string> = {
  entire_home:  "1",
  private_room: "2",
  shared_room:  "3",
  hotel_room:   "4",
};
// ...
searchUrl.searchParams.append("l2_property_type_ids[]", PROPERTY_TYPE_IDS[propertyType]);
```

`l2_property_type_ids[]=N` is Airbnb's **subtype** filter (Apartment, House, Villa, Loft, etc.), not the room-type filter. It does not exclude private or shared rooms. Requesting `propertyType: "entire_home"` therefore returns a mix of entire homes and "Room in a home" listings with shared bathrooms.

I caught this empirically: a search with `propertyType: "entire_home"` returned `https://www.airbnb.com/rooms/27350522` ("Room in Lisbon, Portugal", 1 double bed, shared bathroom, "Room in a home" label on the public listing page).

## The fix

The correct URL parameter is `room_types[]=<label>` with the URL-encoded display name. Concretely:

| `propertyType` | URL value |
|---|---|
| `entire_home` | `Entire home/apt` |
| `private_room` | `Private room` |
| `shared_room` | `Shared room` |
| `hotel_room` | `Hotel room` |

The public input schema does not change, so this is a transparent bug fix for callers.

## Verification

Rebuilt the Docker image and re-ran the same search that previously returned `27350522`. The fixed build emits `room_types[]=Entire+home%2Fapt` on the search URL and the response no longer includes "Room in a home" listings or any other private/shared room. Other results (real entire-home apartments) are preserved.

## Notes

- No new dependencies.
- This is independent of #35 (amenities filter) and can be merged either order.
- I kept the user-facing enum stable, so no migration is needed for existing integrations.