### PR TITLE
feat(details): expose REVIEWS_DEFAULT section with aggregates

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -716,6 +716,22 @@ async function handleAirbnbListingDetails(params: any) {
         }
       }
     },
+    "REVIEWS_DEFAULT": {
+      overallRating: true,
+      overallCount: true,
+      isGuestFavorite: true,
+      ratings: {
+        categoryType: true,
+        localizedRating: true,
+        label: true,
+        percentage: true
+      },
+      ratingDistribution: {
+        label: true,
+        percentage: true,
+        starCount: true
+      }
+    },
     //"AVAILABLITY_CALENDAR_DEFAULT": true,
   };
 


### PR DESCRIPTION
## Summary

`airbnb_listing_details` parses the page state JSON and exposes a subset of sections via `allowSectionSchema`. The `REVIEWS_DEFAULT` section is present in the page state of every listing but is not in the allow list, so review signals are inaccessible to callers today (search-level rating is the only thing they see).

This adds `REVIEWS_DEFAULT` with the aggregate fields that ship in the static page state.

## What gets exposed

- `overallRating` and `overallCount` (also available in search; surfaced here for consistency)
- `isGuestFavorite` boolean
- `ratings`: per-category breakdown (cleanliness, accuracy, check-in, communication, location, value) as `categoryType`, `localizedRating`, `label`, `percentage`
- `ratingDistribution`: 1-5 star bucket histogram as `label`, `percentage`, `starCount`

## What is NOT exposed and why

Individual review text. Airbnb does not include review text in the initial page state; it is fetched asynchronously when the user opens the reviews modal. That endpoint has its own auth/CSRF flow and would require a separate integration to surface. This PR scope is intentionally limited to what is already in the parsed page payload.

## Why it's useful

Agents recommending listings today only have the overall star rating. With this PR they can:

- Distinguish a "4.8 overall, value 4.5" listing (expensive for what it offers) from a "4.8 overall, value 4.9" one.
- Filter out listings where >5% of guests left 1 or 2 stars even when the average is decent.
- Promote Guest Favorite listings explicitly.

## Test

Re-ran `airbnb_listing_details` on listing `23127845` (One Step from Chiado). Output includes:

```
overallRating: 4.88
overallCount: 558
isGuestFavorite: true
ratings: "CLEANLINESS: 4.9 ... VALUE: 4.8"
ratingDistribution: "5: 0.898... 4: 0.090... 1: 0"
```

## Notes

- 16 lines, schema-only change in `allowSectionSchema`. No new dependencies, no new public input.
- Independent of #35 (amenities) and #36 (room_types fix); can be merged any order.