### PR TITLE
Add npm metadata for source and issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,14 @@
   "name": "@openbnb/mcp-server-airbnb",
   "version": "0.2.0",
   "description": "MCP server for Airbnb search and listing details",
+  "homepage": "https://github.com/openbnb-org/mcp-server-airbnb#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/openbnb-org/mcp-server-airbnb.git"
+  },
+  "bugs": {
+    "url": "https://github.com/openbnb-org/mcp-server-airbnb/issues"
+  },
   "license": "MIT",
   "type": "module",
   "author": "OpenBnB (https://openbnb.org)",


### PR DESCRIPTION
## Summary
- add package-level homepage, repository, and bugs metadata for `@openbnb/mcp-server-airbnb`
- point npm users directly to the GitHub README, source repository, and issue tracker

## Validation
- `node -e "const p=require('./package.json'); if(!p.homepage||!p.repository?.url||!p.bugs?.url) process.exit(1);"`
- `npm pack --dry-run --ignore-scripts`
- `git diff --check`