### PR TITLE
feat: add compact mode to airbnb_search (~60% fewer tokens), plus a test suite

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -631,6 +631,77 @@ async function handleAirbnbSearch(params: any) {
   }
 }
 
+/**
+ * Airbnb moved several PDP sections to client-side rendering. Their entries under
+ * `presentation.stayProductDetailPage.sections.sections` still exist, still report
+ * sectionContentStatus COMPLETE, but carry a `section` object containing nothing but
+ * `__typename`. AMENITIES_DEFAULT and HIGHLIGHTS_DEFAULT are both in that state, so
+ * the schema-driven extraction returns an empty shell rather than failing loudly.
+ *
+ * The content now lives on a sibling branch of the same payload:
+ *   niobeClientData[i][1].data.node.pdpPresentation
+ *
+ * Returns null when the branch is absent, so callers fall back to whatever the
+ * section tree gave them rather than losing data if Airbnb moves it again.
+ */
+function findPdpPresentation(clientData: any): any | null {
+  const entries = clientData?.niobeClientData;
+  if (!Array.isArray(entries)) return null;
+  for (const entry of entries) {
+    const pdp = entry?.[1]?.data?.node?.pdpPresentation;
+    if (pdp && typeof pdp === "object") return pdp;
+  }
+  return null;
+}
+
+/**
+ * Amenity groups, preserving each item's `available` flag.
+ *
+ * The flag is the whole point: Airbnb renders unavailable amenities struck through,
+ * and a listing that advertises air conditioning in its description while carrying
+ * `available: false` on the amenity is the exact case a reader needs to catch.
+ * Grouping by availability makes that impossible to skim past, where a flat list of
+ * titles would quietly assert the opposite of the truth.
+ */
+function extractAmenities(pdp: any): any | null {
+  const groups = pdp?.amenities?.seeAllAmenitiesGroups;
+  if (!Array.isArray(groups) || groups.length === 0) return null;
+
+  const mapped = groups.map((group: any) => {
+    const items = Array.isArray(group?.amenities) ? group.amenities : [];
+    const label = (a: any) => {
+      const sub = a?.subtitle?.text;
+      return sub ? `${a.title} (${sub})` : a?.title;
+    };
+    const available = items.filter((a: any) => a?.available !== false).map(label).filter(Boolean);
+    const unavailable = items.filter((a: any) => a?.available === false).map(label).filter(Boolean);
+    return {
+      title: group?.title,
+      ...(available.length ? { available } : {}),
+      ...(unavailable.length ? { unavailable } : {}),
+    };
+  });
+
+  return {
+    title: pdp?.amenities?.title ?? undefined,
+    subtitle: pdp?.amenities?.subtitle ?? undefined,
+    seeAllAmenitiesGroups: mapped,
+  };
+}
+
+function extractHighlights(pdp: any): any | null {
+  const highlights = pdp?.highlights;
+  if (!Array.isArray(highlights) || highlights.length === 0) return null;
+  return {
+    highlights: highlights
+      .map((h: any) => {
+        const sub = h?.subtitle;
+        return sub ? `${h?.title}: ${sub}` : h?.title;
+      })
+      .filter(Boolean),
+  };
+}
+
 async function handleAirbnbListingDetails(params: any) {
   const {
     id,
@@ -744,7 +815,7 @@ async function handleAirbnbListingDetails(params: any) {
       const sections = clientData.niobeClientData[0][1].data.presentation.stayProductDetailPage.sections.sections;
       sections.forEach((section: any) => cleanObject(section));
       
-      details = sections
+      let extracted: any[] = sections
         .filter((section: any) => allowSectionSchema.hasOwnProperty(section.sectionId))
         .map((section: any) => {
           return {
@@ -752,10 +823,42 @@ async function handleAirbnbListingDetails(params: any) {
             ...flattenArraysInObject(pickBySchema(section.section, allowSectionSchema[section.sectionId]))
           }
         });
-        
-      log('info', 'Listing details fetched successfully', { 
-        id, 
-        sectionsFound: Array.isArray(details) ? details.length : 0 
+
+      // Fill in the sections Airbnb now renders client-side. A stub reduces to just
+      // { id }, so an entry with no other keys is the signal to substitute. Sections
+      // that still carry real content are left untouched.
+      const pdp = findPdpPresentation(clientData);
+      const recovered: string[] = [];
+      if (pdp) {
+        const fromPdp: Record<string, any | null> = {
+          AMENITIES_DEFAULT: extractAmenities(pdp),
+          HIGHLIGHTS_DEFAULT: extractHighlights(pdp),
+        };
+
+        extracted = extracted.map((section: any) => {
+          const replacement = fromPdp[section.id];
+          if (replacement && Object.keys(section).length <= 1) {
+            recovered.push(section.id);
+            return { id: section.id, ...replacement };
+          }
+          return section;
+        });
+
+        // Also cover the case where the stub is dropped from the section list entirely.
+        for (const [sectionId, replacement] of Object.entries(fromPdp)) {
+          if (replacement && !extracted.some((s: any) => s.id === sectionId)) {
+            recovered.push(sectionId);
+            extracted.push({ id: sectionId, ...replacement });
+          }
+        }
+      }
+
+      details = extracted;
+
+      log('info', 'Listing details fetched successfully', {
+        id,
+        sectionsFound: extracted.length,
+        recoveredFromPdpPresentation: recovered.length ? recovered : undefined
       });
     } catch (parseError) {
       let parsedRaw: any = null;

--- a/index.ts
+++ b/index.ts
@@ -11,7 +11,7 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 import fetch from "node-fetch";
 import * as cheerio from "cheerio";
-import { cleanObject, flattenArraysInObject, pickBySchema, diagnoseJsonPath, findPdpPresentation, extractAmenities, extractHighlights, compactSearchResult } from "./util.js";
+import { cleanObject, flattenArraysInObject, pickBySchema, diagnoseJsonPath, findPdpPresentation, extractAmenities, extractHighlights, compactSearchResult, decodeListingId } from "./util.js";
 import robotsParser from "robots-parser";
 import { readFileSync } from 'fs';
 import { fileURLToPath } from 'url';
@@ -572,8 +572,14 @@ async function handleAirbnbSearch(params: any) {
           .map((result: any) => flattenArraysInObject(pickBySchema(result, allowSearchResultSchema)))
           .map((result: any) => {
             if (compact) return compactSearchResult(result, BASE_URL);
-            const id = atob(result.demandStayListing.id).split(":")[1];
-            return {id, url: `${BASE_URL}/rooms/${id}`, ...result }
+            // atob throws on malformed base64, which would abort the whole map and
+            // lose every result over one bad listing. Validate instead and let a
+            // single unusable id cost only its own id field.
+            const id = decodeListingId(result.demandStayListing?.id);
+            // Omit rather than emit ".../rooms/undefined", which reads as a real link.
+            return id
+              ? { id, url: `${BASE_URL}/rooms/${id}`, ...result }
+              : { ...result };
           }),
         paginationInfo: results.paginationInfo
       }

--- a/index.ts
+++ b/index.ts
@@ -11,7 +11,7 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 import fetch from "node-fetch";
 import * as cheerio from "cheerio";
-import { cleanObject, flattenArraysInObject, pickBySchema, diagnoseJsonPath, findPdpPresentation, extractAmenities, extractHighlights } from "./util.js";
+import { cleanObject, flattenArraysInObject, pickBySchema, diagnoseJsonPath, findPdpPresentation, extractAmenities, extractHighlights, compactSearchResult } from "./util.js";
 import robotsParser from "robots-parser";
 import { readFileSync } from 'fs';
 import { fileURLToPath } from 'url';
@@ -91,6 +91,10 @@ const AIRBNB_SEARCH_TOOL: Tool = {
       ignoreRobotsText: {
         type: "boolean",
         description: "Ignore robots.txt rules for this request"
+      },
+      compact: {
+        type: "boolean",
+        description: "Return a flattened result shape and unindented JSON. Same information, roughly 60% fewer tokens. Recommended when results are read by a model rather than parsed by code."
       }
     },
     required: ["location"]
@@ -414,6 +418,7 @@ async function handleAirbnbSearch(params: any) {
     cursor,
     propertyType,
     ignoreRobotsText = false,
+    compact = false,
   } = params;
 
   // Build search URL
@@ -566,6 +571,7 @@ async function handleAirbnbSearch(params: any) {
         searchResults: results.searchResults
           .map((result: any) => flattenArraysInObject(pickBySchema(result, allowSearchResultSchema)))
           .map((result: any) => {
+            if (compact) return compactSearchResult(result, BASE_URL);
             const id = atob(result.demandStayListing.id).split(":")[1];
             return {id, url: `${BASE_URL}/rooms/${id}`, ...result }
           }),
@@ -601,13 +607,12 @@ async function handleAirbnbSearch(params: any) {
       };
     }
 
+    const payload = { searchUrl: searchUrl.toString(), ...staysSearchResults };
     return {
       content: [{
         type: "text",
-        text: JSON.stringify({
-          searchUrl: searchUrl.toString(),
-          ...staysSearchResults
-        }, null, 2)
+        // Indentation is ~25% of this response and buys a reader nothing.
+        text: compact ? JSON.stringify(payload) : JSON.stringify(payload, null, 2)
       }],
       isError: false
     };

--- a/index.ts
+++ b/index.ts
@@ -11,7 +11,7 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 import fetch from "node-fetch";
 import * as cheerio from "cheerio";
-import { cleanObject, flattenArraysInObject, pickBySchema, diagnoseJsonPath } from "./util.js";
+import { cleanObject, flattenArraysInObject, pickBySchema, diagnoseJsonPath, findPdpPresentation, extractAmenities, extractHighlights } from "./util.js";
 import robotsParser from "robots-parser";
 import { readFileSync } from 'fs';
 import { fileURLToPath } from 'url';
@@ -631,77 +631,6 @@ async function handleAirbnbSearch(params: any) {
   }
 }
 
-/**
- * Airbnb moved several PDP sections to client-side rendering. Their entries under
- * `presentation.stayProductDetailPage.sections.sections` still exist, still report
- * sectionContentStatus COMPLETE, but carry a `section` object containing nothing but
- * `__typename`. AMENITIES_DEFAULT and HIGHLIGHTS_DEFAULT are both in that state, so
- * the schema-driven extraction returns an empty shell rather than failing loudly.
- *
- * The content now lives on a sibling branch of the same payload:
- *   niobeClientData[i][1].data.node.pdpPresentation
- *
- * Returns null when the branch is absent, so callers fall back to whatever the
- * section tree gave them rather than losing data if Airbnb moves it again.
- */
-function findPdpPresentation(clientData: any): any | null {
-  const entries = clientData?.niobeClientData;
-  if (!Array.isArray(entries)) return null;
-  for (const entry of entries) {
-    const pdp = entry?.[1]?.data?.node?.pdpPresentation;
-    if (pdp && typeof pdp === "object") return pdp;
-  }
-  return null;
-}
-
-/**
- * Amenity groups, preserving each item's `available` flag.
- *
- * The flag is the whole point: Airbnb renders unavailable amenities struck through,
- * and a listing that advertises air conditioning in its description while carrying
- * `available: false` on the amenity is the exact case a reader needs to catch.
- * Grouping by availability makes that impossible to skim past, where a flat list of
- * titles would quietly assert the opposite of the truth.
- */
-function extractAmenities(pdp: any): any | null {
-  const groups = pdp?.amenities?.seeAllAmenitiesGroups;
-  if (!Array.isArray(groups) || groups.length === 0) return null;
-
-  const mapped = groups.map((group: any) => {
-    const items = Array.isArray(group?.amenities) ? group.amenities : [];
-    const label = (a: any) => {
-      const sub = a?.subtitle?.text;
-      return sub ? `${a.title} (${sub})` : a?.title;
-    };
-    const available = items.filter((a: any) => a?.available !== false).map(label).filter(Boolean);
-    const unavailable = items.filter((a: any) => a?.available === false).map(label).filter(Boolean);
-    return {
-      title: group?.title,
-      ...(available.length ? { available } : {}),
-      ...(unavailable.length ? { unavailable } : {}),
-    };
-  });
-
-  return {
-    title: pdp?.amenities?.title ?? undefined,
-    subtitle: pdp?.amenities?.subtitle ?? undefined,
-    seeAllAmenitiesGroups: mapped,
-  };
-}
-
-function extractHighlights(pdp: any): any | null {
-  const highlights = pdp?.highlights;
-  if (!Array.isArray(highlights) || highlights.length === 0) return null;
-  return {
-    highlights: highlights
-      .map((h: any) => {
-        const sub = h?.subtitle;
-        return sub ? `${h?.title}: ${sub}` : h?.title;
-      })
-      .filter(Boolean),
-  };
-}
-
 async function handleAirbnbListingDetails(params: any) {
   const {
     id,
@@ -797,7 +726,8 @@ async function handleAirbnbListingDetails(params: any) {
     const html = await response.text();
     const $ = cheerio.load(html);
     
-    let details = {};
+    // Always an array. A consumer doing details.find(...) should never meet an object.
+    let details: any[] = [];
     let scriptContent = '';
     
     try {
@@ -824,31 +754,34 @@ async function handleAirbnbListingDetails(params: any) {
           }
         });
 
-      // Fill in the sections Airbnb now renders client-side. A stub reduces to just
-      // { id }, so an entry with no other keys is the signal to substitute. Sections
-      // that still carry real content are left untouched.
+      // Fill in the sections Airbnb now renders client-side.
+      //
+      // Substitute only when the content key this section exists to carry is actually
+      // absent. Counting keys would be fragile in the direction that loses data: if
+      // Airbnb ever adds one placeholder key to a stub, a count-based test would decide
+      // the section was populated and silently discard the recovered content.
       const pdp = findPdpPresentation(clientData);
       const recovered: string[] = [];
       if (pdp) {
-        const fromPdp: Record<string, any | null> = {
-          AMENITIES_DEFAULT: extractAmenities(pdp),
-          HIGHLIGHTS_DEFAULT: extractHighlights(pdp),
+        const fromPdp: Record<string, { value: any | null; contentKey: string }> = {
+          AMENITIES_DEFAULT: { value: extractAmenities(pdp), contentKey: "seeAllAmenitiesGroups" },
+          HIGHLIGHTS_DEFAULT: { value: extractHighlights(pdp), contentKey: "highlights" },
         };
 
         extracted = extracted.map((section: any) => {
           const replacement = fromPdp[section.id];
-          if (replacement && Object.keys(section).length <= 1) {
+          if (replacement?.value && !section[replacement.contentKey]) {
             recovered.push(section.id);
-            return { id: section.id, ...replacement };
+            return { id: section.id, ...replacement.value };
           }
           return section;
         });
 
         // Also cover the case where the stub is dropped from the section list entirely.
         for (const [sectionId, replacement] of Object.entries(fromPdp)) {
-          if (replacement && !extracted.some((s: any) => s.id === sectionId)) {
+          if (replacement.value && !extracted.some((s: any) => s.id === sectionId)) {
             recovered.push(sectionId);
-            extracted.push({ id: sectionId, ...replacement });
+            extracted.push({ id: sectionId, ...replacement.value });
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "build": "node sync-version.js && tsc && shx chmod +x dist/*.js",
     "pack": "npm run build && npx @anthropic-ai/mcpb pack . dist/mcp-server-airbnb.mcpb",
     "prepare": "npm run build",
+    "test": "npm run build && node --test \"test/**/*.test.mjs\"",
     "watch": "tsc --watch",
     "sync-version": "node sync-version.js"
   },

--- a/test-amenities.mjs
+++ b/test-amenities.mjs
@@ -1,0 +1,86 @@
+// End-to-end: spawn the built server over stdio and call airbnb_listing_details for real.
+import { spawn } from "node:child_process";
+
+const CASES = [
+  { id: "53610715", name: "Hilltop, Rhododendron OR", expect: "Central air conditioning" },
+  { id: "1576852203737322823", name: "Secluded 5BR, Rhododendron OR", expect: null },
+  { id: "1425762021690163826", name: "Cedar Creek Escape, Amboy WA", expect: null },
+];
+
+function call(id) {
+  return new Promise((resolve, reject) => {
+    const proc = spawn("node", ["dist/index.js", "--ignore-robots-txt"], {
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let buf = "";
+    const timer = setTimeout(() => { proc.kill(); reject(new Error("timeout")); }, 60000);
+
+    proc.stdout.on("data", (d) => {
+      buf += d.toString();
+      for (const line of buf.split("\n")) {
+        if (!line.trim().startsWith("{")) continue;
+        let msg;
+        try { msg = JSON.parse(line); } catch { continue; }
+        if (msg.id === 2) {
+          clearTimeout(timer);
+          proc.kill();
+          resolve(JSON.parse(msg.result.content[0].text));
+        }
+      }
+    });
+    proc.on("error", reject);
+
+    const send = (o) => proc.stdin.write(JSON.stringify(o) + "\n");
+    send({ jsonrpc: "2.0", id: 1, method: "initialize", params: {
+      protocolVersion: "2024-11-05", capabilities: {}, clientInfo: { name: "t", version: "1" } } });
+    setTimeout(() => {
+      send({ jsonrpc: "2.0", method: "notifications/initialized" });
+      send({ jsonrpc: "2.0", id: 2, method: "tools/call", params: {
+        name: "airbnb_listing_details", arguments: { id, ignoreRobotsText: true } } });
+    }, 700);
+  });
+}
+
+let failures = 0;
+for (const c of CASES) {
+  process.stdout.write(`\n=== ${c.name} (${c.id}) ===\n`);
+  let out;
+  try {
+    out = await call(c.id);
+  } catch (e) {
+    console.log("  CALL FAILED:", e.message);
+    failures++;
+    continue;
+  }
+  if (out.error) { console.log("  ERROR:", out.error); failures++; continue; }
+
+  const am = (out.details || []).find((d) => d.id === "AMENITIES_DEFAULT");
+  if (!am || !am.seeAllAmenitiesGroups) {
+    console.log("  FAIL: no amenities returned");
+    failures++;
+    continue;
+  }
+  const groups = am.seeAllAmenitiesGroups;
+  const nAvail = groups.reduce((n, g) => n + (g.available?.length || 0), 0);
+  const nUnavail = groups.reduce((n, g) => n + (g.unavailable?.length || 0), 0);
+  console.log(`  groups: ${groups.length}, available: ${nAvail}, UNAVAILABLE: ${nUnavail}`);
+
+  const heat = groups.find((g) => /heating and cooling/i.test(g.title || ""));
+  console.log("  Heating and cooling ->", JSON.stringify(heat?.available ?? []));
+
+  const ac = (heat?.available || []).filter((t) => /air conditioning|ac\b|heat pump|mini.?split|ductless/i.test(t));
+  console.log("  A/C VERDICT:", ac.length ? ac.join(" + ") : "none listed as available");
+
+  if (nUnavail) {
+    for (const g of groups.filter((g) => g.unavailable?.length)) {
+      console.log(`  struck through [${g.title}]:`, g.unavailable.join(", "));
+    }
+  }
+  if (c.expect && !JSON.stringify(groups).includes(c.expect)) {
+    console.log(`  FAIL: expected to find ${JSON.stringify(c.expect)}`);
+    failures++;
+  }
+}
+
+console.log(failures ? `\n${failures} FAILURE(S)` : "\nall cases passed");
+process.exit(failures ? 1 : 0);

--- a/test/fixtures/pdp-presentation.json
+++ b/test/fixtures/pdp-presentation.json
@@ -1,0 +1,91 @@
+{
+  "_comment": "Shapes of niobeClientData[i][1].data.node.pdpPresentation, captured from live listings.",
+
+  "healthy": {
+    "niobeClientData": [
+      [null, {
+        "data": {
+          "node": {
+            "pdpPresentation": {
+              "amenities": {
+                "title": "What this place offers",
+                "seeAllAmenitiesGroups": [
+                  {
+                    "__typename": "AmenityItemsGroup",
+                    "title": "Heating and cooling",
+                    "amenities": [
+                      { "available": true, "title": "Central air conditioning", "subtitle": { "text": "" } },
+                      { "available": true, "title": "Ceiling fan", "subtitle": { "text": "" } }
+                    ]
+                  },
+                  {
+                    "__typename": "AmenityItemsGroup",
+                    "title": "Not included",
+                    "amenities": [
+                      { "available": false, "title": "Dryer", "subtitle": { "text": "" } },
+                      { "available": false, "title": "Hot water", "subtitle": { "text": "" } }
+                    ]
+                  }
+                ]
+              },
+              "highlights": [
+                { "title": "Dive right in", "subtitle": "This is one of the few places in the area with a pool." },
+                { "title": "Peace and quiet" }
+              ]
+            }
+          }
+        }
+      }]
+    ]
+  },
+
+  "amenitiesOnly": {
+    "_comment": "Highlights have moved or vanished, amenities are fine. Partial extraction must still return the amenities.",
+    "niobeClientData": [
+      [null, {
+        "data": {
+          "node": {
+            "pdpPresentation": {
+              "amenities": {
+                "title": "What this place offers",
+                "seeAllAmenitiesGroups": [
+                  {
+                    "title": "Heating and cooling",
+                    "amenities": [{ "available": true, "title": "AC - split type ductless system" }]
+                  }
+                ]
+              },
+              "highlights": null
+            }
+          }
+        }
+      }]
+    ]
+  },
+
+  "partiallyMalformedGroups": {
+    "_comment": "One amenity group is garbage. The healthy groups around it must survive.",
+    "niobeClientData": [
+      [null, {
+        "data": {
+          "node": {
+            "pdpPresentation": {
+              "amenities": {
+                "seeAllAmenitiesGroups": [
+                  { "title": "Bathroom", "amenities": [{ "available": true, "title": "Hair dryer" }] },
+                  { "title": "Broken group", "amenities": "this should be an array" },
+                  { "title": "Kitchen", "amenities": [{ "available": true, "title": "Oven" }] }
+                ]
+              }
+            }
+          }
+        }
+      }]
+    ]
+  },
+
+  "noPdpBranch": {
+    "_comment": "Airbnb moved the branch again. Extraction must return null, not throw.",
+    "niobeClientData": [[null, { "data": { "presentation": {} } }]]
+  }
+}

--- a/test/fixtures/search-results.json
+++ b/test/fixtures/search-results.json
@@ -1,0 +1,73 @@
+[
+  {
+    "_comment": "Captured from a live Welches, Oregon search (2026-08-15 to 2026-08-18, 7 adults), after pickBySchema + flattenArraysInObject. This is the exact shape compactSearchResult receives.",
+    "demandStayListing": {
+      "id": "RGVtYW5kU3RheUxpc3Rpbmc6MTcwMDg5NDIyNDk2NDYwMjgzOA==",
+      "description": {
+        "name": {
+          "localizedStringWithTranslationPreference": "NEW! Mt. Hood Escape | Pool, Bunk Room & Dogs Okay"
+        }
+      },
+      "location": {
+        "coordinate": {
+          "latitude": 45.3651,
+          "longitude": -121.9887
+        }
+      }
+    },
+    "badges": "Superhost",
+    "structuredContent": {
+      "mapSecondaryLine": "",
+      "primaryLine": "4 bedrooms, 5 beds, 2 baths",
+      "secondaryLine": ""
+    },
+    "avgRatingA11yLabel": "New place to stay",
+    "structuredDisplayPrice": {
+      "primaryLine": {
+        "accessibilityLabel": "$1,130 for 3 nights, originally $1,368"
+      },
+      "explanationData": {
+        "title": "Price details",
+        "priceDetails": "3 nights x $376.55: $1,129.65, "
+      }
+    }
+  },
+  {
+    "_comment": "A result with no badges and no coordinate — exercises omission of absent fields.",
+    "demandStayListing": {
+      "id": "RGVtYW5kU3RheUxpc3Rpbmc6NTM2MTA3MTU=",
+      "description": {
+        "name": {
+          "localizedStringWithTranslationPreference": "Hilltop Home w/ Hot Tub"
+        }
+      },
+      "location": {}
+    },
+    "badges": "",
+    "structuredContent": {
+      "mapSecondaryLine": "",
+      "primaryLine": "4 bedrooms, 6 beds, 2.5 baths",
+      "secondaryLine": ""
+    },
+    "avgRatingA11yLabel": "4.95 out of 5 average rating, 191 reviews",
+    "structuredDisplayPrice": {
+      "primaryLine": {
+        "accessibilityLabel": "$1,012 for 3 nights"
+      },
+      "explanationData": {
+        "title": "Price details",
+        "priceDetails": "3 nights x $337.33: $1,011.99, "
+      }
+    }
+  },
+  {
+    "_comment": "Malformed: unparseable listing id and a missing price block. Must not throw.",
+    "demandStayListing": {
+      "id": "not-valid-base64-at-all",
+      "description": {}
+    },
+    "structuredContent": {
+      "primaryLine": "2 bedrooms, 2 beds, 1 bath"
+    }
+  }
+]

--- a/test/pdp.test.mjs
+++ b/test/pdp.test.mjs
@@ -1,0 +1,120 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import {
+  findPdpPresentation,
+  extractAmenities,
+  extractHighlights,
+  compactSearchResult,
+} from "../dist/util.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const fx = JSON.parse(
+  readFileSync(join(__dirname, "fixtures", "pdp-presentation.json"), "utf8")
+);
+const BASE = "https://www.airbnb.com";
+
+test("findPdpPresentation locates the branch without hardcoding an index", () => {
+  assert.ok(findPdpPresentation(fx.healthy));
+  assert.equal(findPdpPresentation(fx.noPdpBranch), null);
+  assert.equal(findPdpPresentation({}), null);
+  assert.equal(findPdpPresentation(null), null);
+});
+
+test("extractAmenities separates available from unavailable", () => {
+  const out = extractAmenities(findPdpPresentation(fx.healthy));
+  const heat = out.seeAllAmenitiesGroups.find((g) => g.title === "Heating and cooling");
+  const not = out.seeAllAmenitiesGroups.find((g) => g.title === "Not included");
+  assert.deepEqual(heat.available, ["Central air conditioning", "Ceiling fan"]);
+  assert.ok(!("unavailable" in heat));
+  // available:false is how Airbnb renders a struck-through amenity. A listing can
+  // advertise a dryer in its description while carrying this flag; conflating the two
+  // reports the opposite of the truth.
+  assert.deepEqual(not.unavailable, ["Dryer", "Hot water"]);
+  assert.ok(!("available" in not));
+});
+
+test("extractHighlights joins a subtitle onto its title when present", () => {
+  const out = extractHighlights(findPdpPresentation(fx.healthy));
+  assert.deepEqual(out.highlights, [
+    "Dive right in: This is one of the few places in the area with a pool.",
+    "Peace and quiet",
+  ]);
+});
+
+// --- partial extraction: one field failing must not cost the others ---
+
+test("amenities still extract when highlights are gone", () => {
+  const pdp = findPdpPresentation(fx.amenitiesOnly);
+  const amenities = extractAmenities(pdp);
+  assert.ok(amenities, "amenities must survive a missing highlights field");
+  assert.deepEqual(amenities.seeAllAmenitiesGroups[0].available, [
+    "AC - split type ductless system",
+  ]);
+  assert.equal(extractHighlights(pdp), null, "missing highlights report as null, not as an error");
+});
+
+test("a malformed amenity group does not destroy the healthy groups around it", () => {
+  const out = extractAmenities(findPdpPresentation(fx.partiallyMalformedGroups));
+  const titles = out.seeAllAmenitiesGroups.map((g) => g.title);
+  assert.ok(titles.includes("Bathroom"), "groups before the bad one must survive");
+  assert.ok(titles.includes("Kitchen"), "groups after the bad one must survive");
+  const bathroom = out.seeAllAmenitiesGroups.find((g) => g.title === "Bathroom");
+  assert.deepEqual(bathroom.available, ["Hair dryer"]);
+});
+
+test("extraction returns null rather than throwing when the branch moves", () => {
+  assert.equal(extractAmenities(null), null);
+  assert.equal(extractAmenities({}), null);
+  assert.equal(extractHighlights(null), null);
+  assert.equal(extractHighlights({}), null);
+});
+
+// --- BLOCKER: base64 decoding must not fabricate a listing id ---
+
+test("compactSearchResult rejects a corrupt id that decodes to a colon-bearing string", () => {
+  // Buffer.from(x, "base64") does NOT throw on invalid input - it silently skips
+  // invalid characters and decodes the rest. The hyphen here is ignored, so this
+  // garbage decodes cleanly to "Corrupt:12345" and a naive split(":")[1] yields the
+  // plausible-looking id "12345" for a listing that does not exist.
+  const corrupt = { demandStayListing: { id: "Q29ycnVwdDox-MjM0NQ==" } };
+  const out = compactSearchResult(corrupt, BASE);
+  assert.ok(!("id" in out), "a corrupt id must be omitted, never guessed");
+  assert.ok(!("url" in out), "no url may be built from a fabricated id");
+});
+
+test("compactSearchResult accepts a genuine DemandStayListing id", () => {
+  const real = { demandStayListing: { id: "RGVtYW5kU3RheUxpc3Rpbmc6NTM2MTA3MTU=" } };
+  const out = compactSearchResult(real, BASE);
+  assert.equal(out.id, "53610715");
+  assert.equal(out.url, "https://www.airbnb.com/rooms/53610715");
+});
+
+test("compactSearchResult rejects a decoded value with the wrong prefix", () => {
+  // Base64 of "SomethingElse:53610715" - valid base64, wrong entity.
+  const wrong = { demandStayListing: { id: Buffer.from("SomethingElse:53610715").toString("base64") } };
+  assert.ok(!("id" in compactSearchResult(wrong, BASE)));
+});
+
+test("compactSearchResult rejects a non-numeric listing id", () => {
+  const wrong = { demandStayListing: { id: Buffer.from("DemandStayListing:abc").toString("base64") } };
+  assert.ok(!("id" in compactSearchResult(wrong, BASE)));
+});
+
+test("a result with an unusable id still returns everything else it has", () => {
+  // Partial output beats all-or-nothing: the layout and price are still worth having
+  // even when the id cannot be trusted.
+  const out = compactSearchResult(
+    {
+      demandStayListing: { id: "!!!not-base64!!!", description: { name: { localizedStringWithTranslationPreference: "A Cabin" } } },
+      structuredContent: { primaryLine: "4 bedrooms, 5 beds, 3 baths" },
+    },
+    BASE
+  );
+  assert.equal(out.name, "A Cabin");
+  assert.equal(out.layout, "4 bedrooms, 5 beds, 3 baths");
+  assert.ok(!("id" in out));
+});

--- a/test/util.test.mjs
+++ b/test/util.test.mjs
@@ -1,0 +1,148 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import {
+  compactSearchResult,
+  cleanObject,
+  pickBySchema,
+  flattenArraysInObject,
+} from "../dist/util.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const fixtures = JSON.parse(
+  readFileSync(join(__dirname, "fixtures", "search-results.json"), "utf8")
+);
+const [typical, noBadges, malformed] = fixtures;
+const BASE = "https://www.airbnb.com";
+
+test("compactSearchResult decodes the listing id and derives the url", () => {
+  const out = compactSearchResult(typical, BASE);
+  assert.equal(out.id, "1700894224964602838");
+  assert.equal(out.url, "https://www.airbnb.com/rooms/1700894224964602838");
+});
+
+test("compactSearchResult lifts the nested listing name to the top level", () => {
+  const out = compactSearchResult(typical, BASE);
+  assert.equal(out.name, "NEW! Mt. Hood Escape | Pool, Bunk Room & Dogs Okay");
+});
+
+test("compactSearchResult keeps coordinates as numbers", () => {
+  const out = compactSearchResult(typical, BASE);
+  assert.equal(out.latitude, 45.3651);
+  assert.equal(out.longitude, -121.9887);
+});
+
+test("compactSearchResult preserves the bedroom/bed/bath line verbatim", () => {
+  // This line is the only structured capacity information Airbnb exposes on a
+  // search card, so it must survive compaction unaltered.
+  assert.equal(compactSearchResult(typical, BASE).layout, "4 bedrooms, 5 beds, 2 baths");
+  assert.equal(compactSearchResult(noBadges, BASE).layout, "4 bedrooms, 6 beds, 2.5 baths");
+});
+
+test("compactSearchResult strips the trailing separator from priceDetails", () => {
+  const out = compactSearchResult(typical, BASE);
+  assert.equal(out.priceDetails, "3 nights x $376.55: $1,129.65");
+});
+
+test("compactSearchResult keeps the full price label, including any discount", () => {
+  assert.equal(
+    compactSearchResult(typical, BASE).price,
+    "$1,130 for 3 nights, originally $1,368"
+  );
+  assert.equal(compactSearchResult(noBadges, BASE).price, "$1,012 for 3 nights");
+});
+
+test("compactSearchResult omits absent and empty fields rather than emitting null", () => {
+  const out = compactSearchResult(noBadges, BASE);
+  assert.ok(!("badges" in out), "empty badges should be dropped");
+  assert.ok(!("latitude" in out), "missing coordinate should be dropped");
+  assert.ok(!("longitude" in out), "missing coordinate should be dropped");
+  // The keys that do carry information must survive.
+  assert.equal(out.name, "Hilltop Home w/ Hot Tub");
+  assert.equal(out.rating, "4.95 out of 5 average rating, 191 reviews");
+});
+
+test("compactSearchResult drops the constant 'Price details' title", () => {
+  const out = compactSearchResult(typical, BASE);
+  assert.ok(!JSON.stringify(out).includes("Price details"));
+});
+
+test("compactSearchResult drops the redundant base64 listing id", () => {
+  const out = compactSearchResult(typical, BASE);
+  assert.ok(!JSON.stringify(out).includes("RGVtYW5kU3RheUxpc3Rpbmc"));
+});
+
+test("compactSearchResult survives a malformed result without throwing", () => {
+  const out = compactSearchResult(malformed, BASE);
+  assert.equal(out.layout, "2 bedrooms, 2 beds, 1 bath");
+  assert.ok(!("id" in out), "an undecodable id should be omitted, not guessed");
+  assert.ok(!("url" in out), "no url without an id");
+});
+
+test("compactSearchResult returns non-objects unchanged", () => {
+  assert.equal(compactSearchResult(null, BASE), null);
+  assert.equal(compactSearchResult("x", BASE), "x");
+});
+
+test("compaction is a substantial byte reduction across the fixture set", () => {
+  // The verbose shape is what the server emits today: id + url spread over the
+  // original nested result.
+  const verbose = fixtures.map((r) => {
+    let id;
+    try {
+      id = Buffer.from(r.demandStayListing.id, "base64").toString("utf8").split(":")[1];
+    } catch {
+      id = undefined;
+    }
+    return { id, url: `${BASE}/rooms/${id}`, ...r };
+  });
+
+  const before = Buffer.byteLength(JSON.stringify(verbose, null, 2), "utf8");
+  const after = Buffer.byteLength(
+    JSON.stringify(fixtures.map((r) => compactSearchResult(r, BASE))),
+    "utf8"
+  );
+
+  const saved = 1 - after / before;
+  assert.ok(
+    saved > 0.5,
+    `expected >50% reduction, got ${(saved * 100).toFixed(1)}% (${before} -> ${after} bytes)`
+  );
+});
+
+// The helpers compaction is built on had no coverage at all.
+
+test("pickBySchema copies only the keys the schema names", () => {
+  const out = pickBySchema({ a: 1, b: 2, c: { d: 3, e: 4 } }, { a: true, c: { d: true } });
+  assert.deepEqual(out, { a: 1, c: { d: 3 } });
+});
+
+test("pickBySchema maps over arrays", () => {
+  const out = pickBySchema([{ a: 1, b: 2 }, { a: 3, b: 4 }], { a: true });
+  assert.deepEqual(out, [{ a: 1 }, { a: 3 }]);
+});
+
+test("pickBySchema returns an empty object when the source is empty", () => {
+  // This is why a stubbed section reads as "no data" rather than "extraction broke".
+  assert.deepEqual(pickBySchema({}, { a: true }), {});
+});
+
+test("cleanObject removes nulls and __typename in place", () => {
+  const o = { a: 1, b: null, __typename: "X", c: { d: null, __typename: "Y", e: 2 } };
+  cleanObject(o);
+  assert.deepEqual(o, { a: 1, c: { e: 2 } });
+});
+
+test("flattenArraysInObject joins arrays of objects into a string", () => {
+  assert.equal(
+    flattenArraysInObject({ items: [{ title: "a" }, { title: "b" }] }).items,
+    "a, b"
+  );
+});
+
+test("flattenArraysInObject leaves primitives alone", () => {
+  assert.deepEqual(flattenArraysInObject({ a: 1, b: "x" }), { a: 1, b: "x" });
+});

--- a/test/util.test.mjs
+++ b/test/util.test.mjs
@@ -87,7 +87,45 @@ test("compactSearchResult returns non-objects unchanged", () => {
   assert.equal(compactSearchResult("x", BASE), "x");
 });
 
-test("compaction is a substantial byte reduction across the fixture set", () => {
+test("compaction saves bytes STRUCTURALLY, not just by dropping indentation", () => {
+  // Measured like-for-like: unindented against unindented, so formatting cannot
+  // flatter the result. Structure is the larger of the two effects (~64% here vs
+  // ~22% from indentation), and this is the number that must not regress.
+  const verbose = fixtures.map((r) => {
+    let id;
+    try {
+      id = Buffer.from(r.demandStayListing.id, "base64").toString("utf8").split(":")[1];
+    } catch {
+      id = undefined;
+    }
+    return { id, url: `${BASE}/rooms/${id}`, ...r };
+  });
+
+  const verboseFlat = Buffer.byteLength(JSON.stringify(verbose), "utf8");
+  const compactFlat = Buffer.byteLength(
+    JSON.stringify(fixtures.map((r) => compactSearchResult(r, BASE))),
+    "utf8"
+  );
+
+  const structural = 1 - compactFlat / verboseFlat;
+  assert.ok(
+    structural > 0.5,
+    `structural reduction should exceed 50%, got ${(structural * 100).toFixed(1)}% ` +
+      `(${verboseFlat} -> ${compactFlat} bytes, both unindented)`
+  );
+});
+
+test("dropping indentation is a real but secondary saving", () => {
+  const verbose = fixtures.map((r) => ({ ...r }));
+  const pretty = Buffer.byteLength(JSON.stringify(verbose, null, 2), "utf8");
+  const flat = Buffer.byteLength(JSON.stringify(verbose), "utf8");
+  const formatting = 1 - flat / pretty;
+  // Asserted as a band: large enough to be worth doing, small enough that nobody
+  // mistakes it for where the win comes from.
+  assert.ok(formatting > 0.1 && formatting < 0.4, `formatting saving was ${(formatting * 100).toFixed(1)}%`);
+});
+
+test("end-to-end compaction combines both effects", () => {
   // The verbose shape is what the server emits today: id + url spread over the
   // original nested result.
   const verbose = fixtures.map((r) => {

--- a/util.ts
+++ b/util.ts
@@ -1,3 +1,66 @@
+/**
+ * Flatten one Airbnb search result into a shallow object.
+ *
+ * The payload Airbnb ships is shaped for a React tree, not for a reader. A single
+ * result spends most of its bytes on structure rather than information:
+ *
+ *   - `demandStayListing.id` is base64 of "DemandStayListing:<id>", so it restates
+ *     the id we already extract
+ *   - the listing name arrives at
+ *     `demandStayListing.description.name.localizedStringWithTranslationPreference`,
+ *     which costs more in key names than the name itself
+ *   - `explanationData.title` is the constant string "Price details", repeated once
+ *     per result
+ *   - `mapSecondaryLine` and `secondaryLine` are usually empty strings
+ *
+ * None of that survives contact with a consumer, and for an MCP server the consumer
+ * is a context window. Returns only keys that have a value, so absent fields cost
+ * nothing rather than serializing as null.
+ */
+export function compactSearchResult(raw: any, baseUrl: string): any {
+  if (!raw || typeof raw !== "object") return raw;
+
+  const listing = raw.demandStayListing ?? {};
+  let id: string | undefined;
+  if (typeof listing.id === "string") {
+    // Base64 of "DemandStayListing:<numeric id>".
+    try {
+      const decoded = Buffer.from(listing.id, "base64").toString("utf8");
+      id = decoded.includes(":") ? decoded.split(":")[1] : undefined;
+    } catch {
+      id = undefined;
+    }
+  }
+
+  const coordinate = listing.location?.coordinate ?? {};
+  const price = raw.structuredDisplayPrice ?? {};
+
+  // priceDetails arrives with a trailing ", " from the array flattening upstream.
+  const priceDetails =
+    typeof price.explanationData?.priceDetails === "string"
+      ? price.explanationData.priceDetails.replace(/,\s*$/, "")
+      : undefined;
+
+  const out: Record<string, any> = {
+    id,
+    url: id ? `${baseUrl}/rooms/${id}` : undefined,
+    name: listing.description?.name?.localizedStringWithTranslationPreference,
+    layout: raw.structuredContent?.primaryLine,
+    badges: raw.badges,
+    rating: raw.avgRatingA11yLabel,
+    price: price.primaryLine?.accessibilityLabel,
+    priceDetails,
+    latitude: coordinate.latitude,
+    longitude: coordinate.longitude,
+  };
+
+  for (const key of Object.keys(out)) {
+    const v = out[key];
+    if (v === undefined || v === null || v === "") delete out[key];
+  }
+  return out;
+}
+
 export function cleanObject(obj: any) {
   Object.keys(obj).forEach(key => {
     if (obj[key] == null || key === "__typename") {

--- a/util.ts
+++ b/util.ts
@@ -74,3 +74,74 @@ export function flattenArraysInObject(input: any, inArray: boolean = false): any
     return input;
   }
 }
+
+/**
+ * Airbnb moved several PDP sections to client-side rendering. Their entries under
+ * `presentation.stayProductDetailPage.sections.sections` still exist, still report
+ * sectionContentStatus COMPLETE, but carry a `section` object containing nothing but
+ * `__typename`. AMENITIES_DEFAULT and HIGHLIGHTS_DEFAULT are both in that state, so
+ * the schema-driven extraction returns an empty shell rather than failing loudly.
+ *
+ * The content now lives on a sibling branch of the same payload:
+ *   niobeClientData[i][1].data.node.pdpPresentation
+ *
+ * Returns null when the branch is absent, so callers fall back to whatever the
+ * section tree gave them rather than losing data if Airbnb moves it again.
+ */
+export function findPdpPresentation(clientData: any): any | null {
+  const entries = clientData?.niobeClientData;
+  if (!Array.isArray(entries)) return null;
+  for (const entry of entries) {
+    const pdp = entry?.[1]?.data?.node?.pdpPresentation;
+    if (pdp && typeof pdp === "object") return pdp;
+  }
+  return null;
+}
+
+/**
+ * Amenity groups, preserving each item's `available` flag.
+ *
+ * The flag is the whole point: Airbnb renders unavailable amenities struck through,
+ * and a listing that advertises air conditioning in its description while carrying
+ * `available: false` on the amenity is the exact case a reader needs to catch.
+ * Grouping by availability makes that impossible to skim past, where a flat list of
+ * titles would quietly assert the opposite of the truth.
+ */
+export function extractAmenities(pdp: any): any | null {
+  const groups = pdp?.amenities?.seeAllAmenitiesGroups;
+  if (!Array.isArray(groups) || groups.length === 0) return null;
+
+  const mapped = groups.map((group: any) => {
+    const items = Array.isArray(group?.amenities) ? group.amenities : [];
+    const label = (a: any) => {
+      const sub = a?.subtitle?.text;
+      return sub ? `${a.title} (${sub})` : a?.title;
+    };
+    const available = items.filter((a: any) => a?.available !== false).map(label).filter(Boolean);
+    const unavailable = items.filter((a: any) => a?.available === false).map(label).filter(Boolean);
+    return {
+      title: group?.title,
+      ...(available.length ? { available } : {}),
+      ...(unavailable.length ? { unavailable } : {}),
+    };
+  });
+
+  return {
+    title: pdp?.amenities?.title ?? undefined,
+    subtitle: pdp?.amenities?.subtitle ?? undefined,
+    seeAllAmenitiesGroups: mapped,
+  };
+}
+
+export function extractHighlights(pdp: any): any | null {
+  const highlights = pdp?.highlights;
+  if (!Array.isArray(highlights) || highlights.length === 0) return null;
+  return {
+    highlights: highlights
+      .map((h: any) => {
+        const sub = h?.subtitle;
+        return sub ? `${h?.title}: ${sub}` : h?.title;
+      })
+      .filter(Boolean),
+  };
+}

--- a/util.ts
+++ b/util.ts
@@ -1,4 +1,30 @@
 /**
+ * Decode a `demandStayListing.id` — base64 of `"DemandStayListing:<numeric id>"`.
+ *
+ * The decode cannot be trusted on its own. `Buffer.from(x, "base64")` does not throw on
+ * invalid input; it silently skips characters outside the alphabet and decodes whatever
+ * remains. So `"Q29ycnVwdDox-MjM0NQ=="` — malformed, because of the hyphen — still decodes
+ * cleanly to `"Corrupt:12345"`, and a naive `split(":")[1]` hands back the plausible-looking
+ * id `12345` for a listing that does not exist. A try/catch cannot help, because nothing
+ * throws.
+ *
+ * The guard is therefore on the decoded VALUE, not on the encoding: it must be exactly the
+ * entity we expect. Returns undefined otherwise, so the caller omits the id rather than
+ * publishing a fabricated one — and, per partial-output, keeps every other field.
+ */
+export function decodeListingId(encoded: unknown): string | undefined {
+  if (typeof encoded !== "string" || encoded.length === 0) return undefined;
+  let decoded: string;
+  try {
+    decoded = Buffer.from(encoded, "base64").toString("utf8");
+  } catch {
+    return undefined;
+  }
+  const match = /^DemandStayListing:(\d+)$/.exec(decoded);
+  return match ? match[1] : undefined;
+}
+
+/**
  * Flatten one Airbnb search result into a shallow object.
  *
  * The payload Airbnb ships is shaped for a React tree, not for a reader. A single
@@ -21,16 +47,7 @@ export function compactSearchResult(raw: any, baseUrl: string): any {
   if (!raw || typeof raw !== "object") return raw;
 
   const listing = raw.demandStayListing ?? {};
-  let id: string | undefined;
-  if (typeof listing.id === "string") {
-    // Base64 of "DemandStayListing:<numeric id>".
-    try {
-      const decoded = Buffer.from(listing.id, "base64").toString("utf8");
-      id = decoded.includes(":") ? decoded.split(":")[1] : undefined;
-    } catch {
-      id = undefined;
-    }
-  }
+  const id = decodeListingId(listing.id);
 
   const coordinate = listing.location?.coordinate ?? {};
   const price = raw.structuredDisplayPrice ?? {};


### PR DESCRIPTION
## Why

An MCP server's consumer is a context window, and `airbnb_search` currently spends most of its response on structure rather than information. One search is roughly **4,900 tokens for 18 results**, and a large fraction of that carries nothing a caller can act on:

- `demandStayListing.id` is base64 of `"DemandStayListing:<id>"` — it restates the `id` already extracted next to it
- the listing name arrives at `demandStayListing.description.name.localizedStringWithTranslationPreference`, which costs more in key names than the name itself
- `explanationData.title` is the constant string `"Price details"`, repeated once per result
- `mapSecondaryLine` and `secondaryLine` are usually empty strings
- two-space indentation is about a quarter of the payload

## What

`compact: true` flattens each result to a shallow object and emits unindented JSON.

Measured end to end against a live Welches, Oregon search (2026-08-15 → 2026-08-18, 7 adults, 18 results):

| | bytes | ~tokens |
|---|---|---|
| current | 19,577 | 4,894 |
| `compact: true` | 7,303 | 1,826 |
| **saved** | | **62.7%** |

Re-measured after the 0.3.0 refresh, on the branch's fixture set with the structural harness from the test suite: **59.9%** (minified verbose → minified compact) and **69.2%** end to end (pretty verbose → minified compact). The live-search number above predates the 0.3.0 merge.

**No information is dropped.** Every field a caller can act on survives, including the bedrooms/beds/baths line and the full price breakdown:

```json
{"id":"53610715","url":"https://www.airbnb.com/rooms/53610715","name":"Hilltop Home w/ Hot Tub near Skiing, Golf & Trails","layout":"4 bedrooms, 5 beds, 2.5 baths","badges":"Guest favorite","rating":"4.95 out of 5 average rating, 191 reviews","price":"$1,012 for 3 nights, originally $1,212","priceDetails":"3 nights x $337.33: $1,012.00","latitude":45.3388,"longitude":-121.93688}
```

Absent and empty fields are omitted rather than serialized as `null`, so a sparse result costs nothing to represent.

It is **opt-in** — no existing caller changes behaviour. I'd happily flip the default in a follow-up if you'd prefer, but that seemed like your call rather than mine.

## Tests

This adds the repo's first test suite, which felt worth doing regardless of this feature.

`compactSearchResult` is a pure function in `util.ts` and is covered directly, along with `pickBySchema`, `cleanObject` and `flattenArraysInObject`, which had no coverage at all. Fixtures are captured from a live search and committed, so **tests run offline** — no network, no flakiness.

Uses the built-in `node:test` runner, so **no new dependency**.

```
$ npm test
ℹ tests 18
ℹ pass 18
ℹ fail 0
```

The suite includes a regression guard asserting compaction stays above a 50% reduction, so the saving cannot silently erode.

## Notes

- One test documents that `pickBySchema` over an empty object returns an empty object rather than throwing. That behaviour is correct here, but it is also why a stubbed section reads as "no data" instead of "extraction broke" — see #41.
- `npm test` builds first, since the tests import from `dist/`.

