### PR TITLE
test: offline fixture suites for the PR #42 recovery path, plus live-harness fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,11 +244,18 @@ npm run watch
 ### Testing
 
 ```bash
-# Build, then run both suites
+# Build, then run the offline suite
 npm test
 ```
 
-`npm test` drives the built server over stdio and calls the tools for real:
+`npm test` runs the fixture-backed unit suite under `test/*.test.mjs` — no network access, safe for CI and for every install.
+
+```bash
+# Build, then drive the built server over stdio against the real site
+npm run test:live
+```
+
+`npm run test:live` calls the tools for real:
 
 - `test-extension.js` — MCP handshake, tool listing, a search, listing details, and the geocoding paths (Photon, Nominatim fallback)
 - `test-amenities.js` — amenity extraction across several live listings, checking that amenities Airbnb strikes through never appear as ones the listing offers

--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
     "prepare": "npm run build",
     "version": "node sync-version.js && git add manifest.json",
     "pretest": "npm run build",
-    "test": "node test-extension.js && node test-amenities.js",
+    "test": "node --test test/*.test.mjs",
+    "pretest:live": "npm run build",
+    "test:live": "node test-extension.js && node test-amenities.js",
     "watch": "tsc --watch",
     "sync-version": "node sync-version.js"
   },

--- a/test-amenities.js
+++ b/test-amenities.js
@@ -13,7 +13,10 @@ function call(id) {
       stdio: ["pipe", "pipe", "pipe"],
     });
     let buf = "";
+    let toolCallSent = false;
     const timer = setTimeout(() => { proc.kill(); reject(new Error("timeout")); }, 60000);
+
+    const send = (o) => proc.stdin.write(JSON.stringify(o) + "\n");
 
     proc.stdout.on("data", (d) => {
       buf += d.toString();
@@ -21,23 +24,36 @@ function call(id) {
         if (!line.trim().startsWith("{")) continue;
         let msg;
         try { msg = JSON.parse(line); } catch { continue; }
+
+        // The id-1 reply, not a fixed sleep, is what says the server is ready.
+        if (msg.id === 1 && !toolCallSent) {
+          toolCallSent = true;
+          send({ jsonrpc: "2.0", method: "notifications/initialized" });
+          send({ jsonrpc: "2.0", id: 2, method: "tools/call", params: {
+            name: "airbnb_listing_details", arguments: { id, ignoreRobotsText: true } } });
+          continue;
+        }
+
         if (msg.id === 2) {
           clearTimeout(timer);
           proc.kill();
-          resolve(JSON.parse(msg.result.content[0].text));
+          if (msg.error) {
+            reject(new Error(`JSON-RPC error: ${JSON.stringify(msg.error)}`));
+            return;
+          }
+          const text = msg.result?.content?.[0]?.text;
+          if (!text) {
+            reject(new Error(`malformed tools/call response: ${JSON.stringify(msg)}`));
+            return;
+          }
+          resolve(JSON.parse(text));
         }
       }
     });
     proc.on("error", reject);
 
-    const send = (o) => proc.stdin.write(JSON.stringify(o) + "\n");
     send({ jsonrpc: "2.0", id: 1, method: "initialize", params: {
       protocolVersion: "2024-11-05", capabilities: {}, clientInfo: { name: "t", version: "1" } } });
-    setTimeout(() => {
-      send({ jsonrpc: "2.0", method: "notifications/initialized" });
-      send({ jsonrpc: "2.0", id: 2, method: "tools/call", params: {
-        name: "airbnb_listing_details", arguments: { id, ignoreRobotsText: true } } });
-    }, 700);
   });
 }
 

--- a/test-extension.js
+++ b/test-extension.js
@@ -24,7 +24,7 @@ class MCPTester {
 
   async startServer() {
     console.log('🚀 Starting MCP server...');
-    
+
     this.server = spawn('node', [SERVER_PATH, '--ignore-robots-txt'], {
       stdio: ['pipe', 'pipe', 'pipe'],
       env: { ...process.env, IGNORE_ROBOTS_TXT: 'true' }
@@ -34,13 +34,21 @@ class MCPTester {
       console.log('📋 Server log:', data.toString().trim());
     });
 
-    // Wait for server to start
-    await new Promise(resolve => setTimeout(resolve, 2000));
-    
     if (this.server.killed) {
       throw new Error('Server failed to start');
     }
-    
+
+    // Await the real initialize response instead of a fixed sleep.
+    const initResponse = await this.sendRequest('initialize', {
+      protocolVersion: '2024-11-05',
+      capabilities: {},
+      clientInfo: { name: 'test-extension', version: '1' },
+    });
+    if (initResponse.error) {
+      throw new Error(`initialize failed: ${initResponse.error.message}`);
+    }
+    this.server.stdin.write(JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' }) + '\n');
+
     console.log('✅ Server started successfully');
   }
 
@@ -260,6 +268,11 @@ class MCPTester {
           name: 'airbnb_search',
           arguments: { location: c.location, ignoreRobotsText: true },
         });
+        if (response.error) {
+          console.log(`   ❌ ${c.label}: JSON-RPC error: ${response.error.message || JSON.stringify(response.error)}`);
+          allOk = false;
+          continue;
+        }
         const url = this._extractSearchUrl(response);
         const bbox = parseBbox(url);
         if (!bbox) {

--- a/test/fixtures/pdp-presentation.json
+++ b/test/fixtures/pdp-presentation.json
@@ -1,0 +1,121 @@
+{
+  "_comment": "Shapes of niobeClientData[i][1].data.node.pdpPresentation. 'healthy' is trimmed from a real listing payload; the others are synthesized to exercise specific edge cases. Real entries carry a string operation-name key at index 0, not null.",
+
+  "healthy": {
+    "niobeClientData": [
+      ["StaysPdpSectionsQuery", { "data": { "presentation": {} } }],
+      ["StaysPdpReviewsQuery", {
+        "data": {
+          "node": {
+            "pdpPresentation": {
+              "amenities": {
+                "title": "What this place offers",
+                "seeAllAmenitiesGroups": [
+                  {
+                    "__typename": "AmenityItemsGroup",
+                    "title": "Heating and cooling",
+                    "amenities": [
+                      { "available": true, "title": "Central air conditioning", "subtitle": { "text": "" } },
+                      { "available": true, "title": "Ceiling fan", "subtitle": { "text": "" } }
+                    ]
+                  },
+                  {
+                    "__typename": "AmenityItemsGroup",
+                    "title": "Not included",
+                    "amenities": [
+                      { "available": false, "title": "Dryer", "subtitle": { "text": "" } },
+                      { "available": false, "title": "Hot water", "subtitle": { "text": "" } }
+                    ]
+                  }
+                ]
+              },
+              "highlights": [
+                { "title": "Dive right in", "subtitle": "This is one of the few places in the area with a pool." },
+                { "title": "Peace and quiet" }
+              ]
+            }
+          }
+        }
+      }]
+    ]
+  },
+
+  "amenitiesOnly": {
+    "_comment": "Highlights have moved or vanished, amenities are fine. Partial extraction must still return the amenities.",
+    "niobeClientData": [
+      ["StaysPdpSectionsQuery", {
+        "data": {
+          "node": {
+            "pdpPresentation": {
+              "amenities": {
+                "title": "What this place offers",
+                "seeAllAmenitiesGroups": [
+                  {
+                    "title": "Heating and cooling",
+                    "amenities": [{ "available": true, "title": "AC - split type ductless system" }]
+                  }
+                ]
+              },
+              "highlights": null
+            }
+          }
+        }
+      }]
+    ]
+  },
+
+  "partiallyMalformedGroups": {
+    "_comment": "One amenity group is garbage. The healthy groups around it must survive.",
+    "niobeClientData": [
+      ["StaysPdpSectionsQuery", {
+        "data": {
+          "node": {
+            "pdpPresentation": {
+              "amenities": {
+                "seeAllAmenitiesGroups": [
+                  { "title": "Bathroom", "amenities": [{ "available": true, "title": "Hair dryer" }] },
+                  { "title": "Broken group", "amenities": "this should be an array" },
+                  { "title": "Kitchen", "amenities": [{ "available": true, "title": "Oven" }] }
+                ]
+              }
+            }
+          }
+        }
+      }]
+    ]
+  },
+
+  "noPdpBranch": {
+    "_comment": "Airbnb moved the branch again. Extraction must return null, not throw.",
+    "niobeClientData": [["StaysPdpSectionsQuery", { "data": { "presentation": {} } }]]
+  },
+
+  "subtitleShapes": {
+    "_comment": "Airbnb has shipped amenity and highlight subtitles as both a plain string and a { text } object. Both shapes must produce the same label.",
+    "niobeClientData": [
+      ["StaysPdpSectionsQuery", {
+        "data": {
+          "node": {
+            "pdpPresentation": {
+              "amenities": {
+                "seeAllAmenitiesGroups": [
+                  {
+                    "title": "Bathroom",
+                    "amenities": [
+                      { "available": true, "title": "Shampoo", "subtitle": "Body wash" },
+                      { "available": true, "title": "Hair dryer", "subtitle": { "text": "1200W" } }
+                    ]
+                  }
+                ]
+              },
+              "highlights": [
+                { "title": "Great location", "subtitle": "Walk to the beach" },
+                { "title": "Self check-in", "subtitle": { "text": "Check yourself in with the keypad." } }
+              ]
+            }
+          }
+        }
+      }]
+    ]
+  }
+}

--- a/test/pdp.test.mjs
+++ b/test/pdp.test.mjs
@@ -1,0 +1,213 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import {
+  findPdpPresentation,
+  extractAmenities,
+  extractHighlights,
+  keyAmenityGroups,
+} from "../dist/util.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const fx = JSON.parse(
+  readFileSync(join(__dirname, "fixtures", "pdp-presentation.json"), "utf8")
+);
+
+test("findPdpPresentation locates the branch without hardcoding an index", () => {
+  assert.ok(findPdpPresentation(fx.healthy));
+  assert.equal(findPdpPresentation(fx.noPdpBranch), null);
+  assert.equal(findPdpPresentation({}), null);
+  assert.equal(findPdpPresentation(null), null);
+});
+
+test("extractAmenities passes through the section title", () => {
+  const out = extractAmenities(findPdpPresentation(fx.healthy));
+  assert.equal(out.title, "What this place offers");
+});
+
+test("an all-unavailable group is left unmarked; its title carries the meaning", () => {
+  const out = extractAmenities(findPdpPresentation(fx.healthy));
+  const heat = out.seeAllAmenitiesGroups.find((g) => g.title === "Heating and cooling");
+  const not = out.seeAllAmenitiesGroups.find((g) => g.title === "Not included");
+  assert.deepEqual(heat.amenities, ["Central air conditioning", "Ceiling fan"]);
+  // available:false is how Airbnb renders a struck-through amenity. The mechanism
+  // is availability homogeneity, not the group's title: a group where every item
+  // shares the same availability is left unmarked because the group's own name -
+  // whatever it is - already tells the story. Only a group mixing available and
+  // unavailable items needs its unavailable items called out individually. This
+  // fixture's homogeneous group happens to be titled "Not included", but that
+  // title is not what triggers the behavior - see the next test.
+  assert.deepEqual(not.amenities, ["Dryer", "Hot water"]);
+});
+
+test("a homogeneously-unavailable group is left unmarked under any title, not just 'Not included'", () => {
+  const pdp = {
+    amenities: {
+      seeAllAmenitiesGroups: [
+        {
+          title: "Kitchen extras",
+          amenities: [
+            { title: "Wine glasses", available: false },
+            { title: "Coffee maker", available: false },
+          ],
+        },
+      ],
+    },
+  };
+  const out = extractAmenities(pdp);
+  assert.deepEqual(out.seeAllAmenitiesGroups[0].amenities, ["Wine glasses", "Coffee maker"]);
+});
+
+test("a group mixing available and unavailable items marks the unavailable ones", () => {
+  const pdp = {
+    amenities: {
+      seeAllAmenitiesGroups: [
+        {
+          title: "Laundry",
+          amenities: [
+            { title: "Washer", available: true },
+            { title: "Dryer", available: false },
+          ],
+        },
+      ],
+    },
+  };
+  const out = extractAmenities(pdp);
+  assert.deepEqual(out.seeAllAmenitiesGroups[0].amenities, [
+    "Washer",
+    "Dryer — unavailable",
+  ]);
+});
+
+test("extractHighlights joins a subtitle onto its title when present", () => {
+  const out = extractHighlights(findPdpPresentation(fx.healthy));
+  assert.deepEqual(out.highlights, [
+    "Dive right in: This is one of the few places in the area with a pool.",
+    "Peace and quiet",
+  ]);
+});
+
+// --- partial extraction: one field failing must not cost the others ---
+
+test("amenities still extract when highlights are gone", () => {
+  const pdp = findPdpPresentation(fx.amenitiesOnly);
+  const amenities = extractAmenities(pdp);
+  assert.ok(amenities, "amenities must survive a missing highlights field");
+  assert.deepEqual(amenities.seeAllAmenitiesGroups[0].amenities, [
+    "AC - split type ductless system",
+  ]);
+  assert.equal(extractHighlights(pdp), null, "missing highlights report as null, not as an error");
+});
+
+test("a malformed amenity group does not destroy the healthy groups around it", () => {
+  const out = extractAmenities(findPdpPresentation(fx.partiallyMalformedGroups));
+  const titles = out.seeAllAmenitiesGroups.map((g) => g.title);
+  assert.ok(titles.includes("Bathroom"), "groups before the bad one must survive");
+  assert.ok(titles.includes("Kitchen"), "groups after the bad one must survive");
+  const bathroom = out.seeAllAmenitiesGroups.find((g) => g.title === "Bathroom");
+  assert.deepEqual(bathroom.amenities, ["Hair dryer"]);
+});
+
+test("extraction returns null rather than throwing when the branch moves", () => {
+  assert.equal(extractAmenities(null), null);
+  assert.equal(extractAmenities({}), null);
+  assert.equal(extractHighlights(null), null);
+  assert.equal(extractHighlights({}), null);
+});
+
+test("extractAmenities returns null when every group is empty", () => {
+  const pdp = {
+    amenities: {
+      seeAllAmenitiesGroups: [
+        { title: "Bathroom", amenities: [] },
+        { title: "Kitchen", amenities: [] },
+      ],
+    },
+  };
+  assert.equal(extractAmenities(pdp), null);
+});
+
+// --- subtitle shape: Airbnb has shipped this as both a plain string and a
+// { text } object, on both amenities and highlights. Both must label the same. ---
+
+test("extractAmenities labels a string subtitle and a { text } subtitle identically", () => {
+  const pdp = findPdpPresentation(fx.subtitleShapes);
+  const out = extractAmenities(pdp);
+  assert.deepEqual(out.seeAllAmenitiesGroups[0].amenities, [
+    "Shampoo (Body wash)",
+    "Hair dryer (1200W)",
+  ]);
+});
+
+test("extractHighlights labels a string subtitle and a { text } subtitle identically", () => {
+  const pdp = findPdpPresentation(fx.subtitleShapes);
+  const out = extractHighlights(pdp);
+  assert.deepEqual(out.highlights, [
+    "Great location: Walk to the beach",
+    "Self check-in: Check yourself in with the keypad.",
+  ]);
+});
+
+// --- keyAmenityGroups: no coverage at all before this branch ---
+
+test("keyAmenityGroups keys groups by title", () => {
+  const section = {
+    seeAllAmenitiesGroups: [
+      { title: "Bathroom", amenities: [{ title: "Hair dryer" }] },
+      { title: "Kitchen", amenities: [{ title: "Oven" }] },
+    ],
+  };
+  const out = keyAmenityGroups(section);
+  assert.deepEqual(out.seeAllAmenitiesGroups, {
+    Bathroom: [{ title: "Hair dryer" }],
+    Kitchen: [{ title: "Oven" }],
+  });
+});
+
+test("keyAmenityGroups falls back to 'Other' for an untitled group", () => {
+  const section = {
+    seeAllAmenitiesGroups: [{ amenities: [{ title: "Mystery item" }] }],
+  };
+  const out = keyAmenityGroups(section);
+  assert.deepEqual(out.seeAllAmenitiesGroups, { Other: [{ title: "Mystery item" }] });
+});
+
+test("keyAmenityGroups merges duplicate titles by concatenation, not overwrite", () => {
+  const section = {
+    seeAllAmenitiesGroups: [
+      { title: "Bathroom", amenities: [{ title: "Hair dryer" }] },
+      { title: "Bathroom", amenities: [{ title: "Shampoo" }] },
+    ],
+  };
+  const out = keyAmenityGroups(section);
+  assert.deepEqual(out.seeAllAmenitiesGroups.Bathroom, [
+    { title: "Hair dryer" },
+    { title: "Shampoo" },
+  ]);
+});
+
+test("keyAmenityGroups drops groups that have no amenities", () => {
+  const section = {
+    seeAllAmenitiesGroups: [
+      { title: "Bathroom", amenities: [] },
+      { title: "Kitchen", amenities: [{ title: "Oven" }] },
+    ],
+  };
+  const out = keyAmenityGroups(section);
+  assert.deepEqual(out.seeAllAmenitiesGroups, { Kitchen: [{ title: "Oven" }] });
+  assert.ok(!("Bathroom" in out.seeAllAmenitiesGroups));
+});
+
+test("keyAmenityGroups passes through non-matching objects, arrays, and null unchanged", () => {
+  assert.equal(keyAmenityGroups(null), null);
+  assert.equal(keyAmenityGroups(42), 42);
+
+  const arr = [1, 2, 3];
+  assert.equal(keyAmenityGroups(arr), arr);
+
+  const noGroups = { foo: "bar" };
+  assert.deepEqual(keyAmenityGroups(noGroups), noGroups);
+});

--- a/test/util.test.mjs
+++ b/test/util.test.mjs
@@ -1,0 +1,38 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { cleanObject, pickBySchema, flattenArraysInObject } from "../dist/util.js";
+
+// The helpers amenity/highlight recovery is built on had no coverage at all.
+
+test("pickBySchema copies only the keys the schema names", () => {
+  const out = pickBySchema({ a: 1, b: 2, c: { d: 3, e: 4 } }, { a: true, c: { d: true } });
+  assert.deepEqual(out, { a: 1, c: { d: 3 } });
+});
+
+test("pickBySchema maps over arrays", () => {
+  const out = pickBySchema([{ a: 1, b: 2 }, { a: 3, b: 4 }], { a: true });
+  assert.deepEqual(out, [{ a: 1 }, { a: 3 }]);
+});
+
+test("pickBySchema returns an empty object when the source is empty", () => {
+  // This is why a stubbed section reads as "no data" rather than "extraction broke".
+  assert.deepEqual(pickBySchema({}, { a: true }), {});
+});
+
+test("cleanObject removes nulls and __typename in place", () => {
+  const o = { a: 1, b: null, __typename: "X", c: { d: null, __typename: "Y", e: 2 } };
+  cleanObject(o);
+  assert.deepEqual(o, { a: 1, c: { e: 2 } });
+});
+
+test("flattenArraysInObject joins arrays of objects into a string", () => {
+  assert.equal(
+    flattenArraysInObject({ items: [{ title: "a" }, { title: "b" }] }).items,
+    "a, b"
+  );
+});
+
+test("flattenArraysInObject leaves primitives alone", () => {
+  assert.deepEqual(flattenArraysInObject({ a: 1, b: "x" }), { a: 1, b: "x" });
+});


### PR DESCRIPTION
## What this covers

PR #42 recovered `amenities` and `highlights` from `pdpPresentation` when
Airbnb's normal section tree ships an empty client-side-rendered stub, but it
shipped with no tests and no committed fixtures. This adds an offline
`node --test` suite (`test/pdp.test.mjs`, `test/util.test.mjs`) backed by a
committed fixture file (`test/fixtures/pdp-presentation.json`) covering:

- `findPdpPresentation` locating the `niobeClientData` branch without
  hardcoding an index — the fixture leads with a decoy entry that has no
  `pdpPresentation`, so an `entries[0]`-only implementation fails the test —
  and returning `null` (not throwing) when the branch has moved or is
  absent.
- `extractAmenities`: normal groups, the section title passing through, a
  homogeneously-unavailable group left unmarked regardless of its title
  (the mechanism is availability homogeneity, not the "Not included" name),
  a group mixing available and unavailable items marking only the
  unavailable ones, a malformed group that must not take down the healthy
  groups around it, and `null` when every group is empty.
- `extractHighlights`, including the case where highlights are gone but
  amenities still extract fine (partial extraction, not all-or-nothing).
- `keyAmenityGroups`, which had zero coverage before this: keying groups by
  title, an untitled group falling back to `"Other"`, duplicate titles
  merging by concatenation rather than overwriting, non-matching
  objects/arrays/`null` passing through unchanged, and empty groups being
  dropped.
- `pickBySchema`, `cleanObject`, and `flattenArraysInObject` — the
  compaction helpers the recovery path is built on, which also had no tests.

## The subtitle shape pin

Airbnb has shipped the amenity and highlight `subtitle` field as both a
plain string and a `{ text }` object. `extractAmenities`/`extractHighlights`
already handle both, but nothing pinned it. Added a fixture scenario
(`subtitleShapes`) with one amenity and one highlight of each shape, and a
test asserting both produce the same label (`"Title (sub)"` for amenities,
`"Title: sub"` for highlights) regardless of which shape Airbnb sends.

## npm test vs npm run test:live

`npm test` now runs the offline suite: `node --test test/*.test.mjs`, with
the shell (not `--test`'s own glob support) expanding the pattern — that
form works back to Node 18, which the README still lists as the minimum
supported version; `--test`'s built-in glob positionals need Node 21+ and
would silently pass zero files (exit 0) on older runtimes. It can run in CI
and on every install without hitting the network.

`test-extension.js` and `test-amenities.js` are real end-to-end checks
against a live-spawned server and real Airbnb responses — they still exist
and still run in one command, just moved to `npm run test:live`
(`pretest:live` still chains the build), one command away from `npm test`
rather than folded into it.

## Live-harness fixes

Both harnesses had the same two bugs, now fixed in both:

- Neither awaited the `initialize` response (id 1) before proceeding.
  `test-amenities.js`'s `call()` sent `tools/call` after a fixed 700ms
  sleep; `test-extension.js`'s `startServer()` never sent `initialize` at
  all and just slept 2s before issuing `tools/list`. Both now send
  `initialize` and wait for its actual response before moving on — no
  longer flaky under a slow start, no longer needlessly slow under a fast
  one.
- A JSON-RPC error reply wasn't handled safely everywhere. In
  `test-amenities.js`, `msg.result.content[0].text` was read unguarded, so
  an error reply (`msg.error` instead of `msg.result`) threw inside the
  stdout listener and killed the whole run; it's now guarded and reported
  as a normal test failure. In `test-extension.js`, `testGeocoding()` passed
  the raw response straight to its URL-extraction helper without checking
  `response.error` first, so a JSON-RPC error there was misreported as
  "geocoding silently failed" rather than surfaced as the actual error;
  it now checks `response.error` before extracting.

## Scope note

This branch is scoped strictly to upstream's current `util.ts` exports:
`cleanObject`, `flattenArraysInObject`, `pickBySchema`, `findPdpPresentation`,
`extractAmenities`, `extractHighlights`, and `keyAmenityGroups` all have
test coverage here. `diagnoseJsonPath` is also part of that export set but
is untested on both this branch and upstream's existing suite — left as-is
rather than adding coverage beyond what this PR is scoped to. Fixtures and
test scenarios that only existed to exercise functions not present on
`main` were left out.
