### PR TITLE
fix: recover LOCATION_DEFAULT coordinates from node.location when stubbed

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,11 +244,18 @@ npm run watch
 ### Testing
 
 ```bash
-# Build, then run both suites
+# Build, then run the offline suite
 npm test
 ```
 
-`npm test` drives the built server over stdio and calls the tools for real:
+`npm test` runs the fixture-backed unit suite under `test/*.test.mjs` — no network access, safe for CI and for every install.
+
+```bash
+# Build, then drive the built server over stdio against the real site
+npm run test:live
+```
+
+`npm run test:live` calls the tools for real:
 
 - `test-extension.js` — MCP handshake, tool listing, a search, listing details, and the geocoding paths (Photon, Nominatim fallback)
 - `test-amenities.js` — amenity extraction across several live listings, checking that amenities Airbnb strikes through never appear as ones the listing offers

--- a/index.ts
+++ b/index.ts
@@ -11,7 +11,7 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 import fetch from "node-fetch";
 import * as cheerio from "cheerio";
-import { cleanObject, flattenArraysInObject, pickBySchema, diagnoseJsonPath, findPdpPresentation, extractAmenities, extractHighlights, keyAmenityGroups } from "./util.js";
+import { cleanObject, flattenArraysInObject, pickBySchema, diagnoseJsonPath, findPdpPresentation, extractAmenities, extractHighlights, keyAmenityGroups, findNodeLocation, extractLocationCoordinate, recoverLocationSection } from "./util.js";
 import robotsParser from "robots-parser";
 import { readFileSync } from 'fs';
 import { fileURLToPath } from 'url';
@@ -787,6 +787,19 @@ async function handleAirbnbListingDetails(params: any) {
             extracted.push({ id: sectionId, ...flattenArraysInObject(keyAmenityGroups(replacement.value)) });
           }
         }
+      }
+
+      // LOCATION_DEFAULT gets the same fromPdp-style recovery, but its source is a
+      // sibling branch of the node (node.location) rather than node.pdpPresentation,
+      // so Airbnb can stub it independently of the amenities/highlights move. Without
+      // this, a stubbed section silently reports success with no coordinates - the
+      // exact failure mode that killed mcp.openbnb.ai.
+      const locationCoordinate = extractLocationCoordinate(findNodeLocation(clientData));
+      if (locationCoordinate) {
+        const before = extracted.find((s: any) => s.id === "LOCATION_DEFAULT");
+        const alreadyHadCoords = before && Number.isFinite(before.lat) && Number.isFinite(before.lng);
+        extracted = recoverLocationSection(extracted, locationCoordinate);
+        if (!alreadyHadCoords) recovered.push("LOCATION_DEFAULT");
       }
 
       details = extracted;

--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
     "prepare": "npm run build",
     "version": "node sync-version.js && git add manifest.json",
     "pretest": "npm run build",
-    "test": "node test-extension.js && node test-amenities.js",
+    "test": "node --test test/*.test.mjs",
+    "pretest:live": "npm run build",
+    "test:live": "node test-extension.js && node test-amenities.js",
     "watch": "tsc --watch",
     "sync-version": "node sync-version.js"
   },

--- a/test-amenities.js
+++ b/test-amenities.js
@@ -13,7 +13,10 @@ function call(id) {
       stdio: ["pipe", "pipe", "pipe"],
     });
     let buf = "";
+    let toolCallSent = false;
     const timer = setTimeout(() => { proc.kill(); reject(new Error("timeout")); }, 60000);
+
+    const send = (o) => proc.stdin.write(JSON.stringify(o) + "\n");
 
     proc.stdout.on("data", (d) => {
       buf += d.toString();
@@ -21,23 +24,36 @@ function call(id) {
         if (!line.trim().startsWith("{")) continue;
         let msg;
         try { msg = JSON.parse(line); } catch { continue; }
+
+        // The id-1 reply, not a fixed sleep, is what says the server is ready.
+        if (msg.id === 1 && !toolCallSent) {
+          toolCallSent = true;
+          send({ jsonrpc: "2.0", method: "notifications/initialized" });
+          send({ jsonrpc: "2.0", id: 2, method: "tools/call", params: {
+            name: "airbnb_listing_details", arguments: { id, ignoreRobotsText: true } } });
+          continue;
+        }
+
         if (msg.id === 2) {
           clearTimeout(timer);
           proc.kill();
-          resolve(JSON.parse(msg.result.content[0].text));
+          if (msg.error) {
+            reject(new Error(`JSON-RPC error: ${JSON.stringify(msg.error)}`));
+            return;
+          }
+          const text = msg.result?.content?.[0]?.text;
+          if (!text) {
+            reject(new Error(`malformed tools/call response: ${JSON.stringify(msg)}`));
+            return;
+          }
+          resolve(JSON.parse(text));
         }
       }
     });
     proc.on("error", reject);
 
-    const send = (o) => proc.stdin.write(JSON.stringify(o) + "\n");
     send({ jsonrpc: "2.0", id: 1, method: "initialize", params: {
       protocolVersion: "2024-11-05", capabilities: {}, clientInfo: { name: "t", version: "1" } } });
-    setTimeout(() => {
-      send({ jsonrpc: "2.0", method: "notifications/initialized" });
-      send({ jsonrpc: "2.0", id: 2, method: "tools/call", params: {
-        name: "airbnb_listing_details", arguments: { id, ignoreRobotsText: true } } });
-    }, 700);
   });
 }
 

--- a/test-extension.js
+++ b/test-extension.js
@@ -24,7 +24,7 @@ class MCPTester {
 
   async startServer() {
     console.log('🚀 Starting MCP server...');
-    
+
     this.server = spawn('node', [SERVER_PATH, '--ignore-robots-txt'], {
       stdio: ['pipe', 'pipe', 'pipe'],
       env: { ...process.env, IGNORE_ROBOTS_TXT: 'true' }
@@ -34,13 +34,21 @@ class MCPTester {
       console.log('📋 Server log:', data.toString().trim());
     });
 
-    // Wait for server to start
-    await new Promise(resolve => setTimeout(resolve, 2000));
-    
     if (this.server.killed) {
       throw new Error('Server failed to start');
     }
-    
+
+    // Await the real initialize response instead of a fixed sleep.
+    const initResponse = await this.sendRequest('initialize', {
+      protocolVersion: '2024-11-05',
+      capabilities: {},
+      clientInfo: { name: 'test-extension', version: '1' },
+    });
+    if (initResponse.error) {
+      throw new Error(`initialize failed: ${initResponse.error.message}`);
+    }
+    this.server.stdin.write(JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' }) + '\n');
+
     console.log('✅ Server started successfully');
   }
 
@@ -260,6 +268,11 @@ class MCPTester {
           name: 'airbnb_search',
           arguments: { location: c.location, ignoreRobotsText: true },
         });
+        if (response.error) {
+          console.log(`   ❌ ${c.label}: JSON-RPC error: ${response.error.message || JSON.stringify(response.error)}`);
+          allOk = false;
+          continue;
+        }
         const url = this._extractSearchUrl(response);
         const bbox = parseBbox(url);
         if (!bbox) {

--- a/test/fixtures/pdp-presentation.json
+++ b/test/fixtures/pdp-presentation.json
@@ -1,0 +1,121 @@
+{
+  "_comment": "Shapes of niobeClientData[i][1].data.node.pdpPresentation. 'healthy' is trimmed from a real listing payload; the others are synthesized to exercise specific edge cases. Real entries carry a string operation-name key at index 0, not null.",
+
+  "healthy": {
+    "niobeClientData": [
+      ["StaysPdpSectionsQuery", { "data": { "presentation": {} } }],
+      ["StaysPdpReviewsQuery", {
+        "data": {
+          "node": {
+            "pdpPresentation": {
+              "amenities": {
+                "title": "What this place offers",
+                "seeAllAmenitiesGroups": [
+                  {
+                    "__typename": "AmenityItemsGroup",
+                    "title": "Heating and cooling",
+                    "amenities": [
+                      { "available": true, "title": "Central air conditioning", "subtitle": { "text": "" } },
+                      { "available": true, "title": "Ceiling fan", "subtitle": { "text": "" } }
+                    ]
+                  },
+                  {
+                    "__typename": "AmenityItemsGroup",
+                    "title": "Not included",
+                    "amenities": [
+                      { "available": false, "title": "Dryer", "subtitle": { "text": "" } },
+                      { "available": false, "title": "Hot water", "subtitle": { "text": "" } }
+                    ]
+                  }
+                ]
+              },
+              "highlights": [
+                { "title": "Dive right in", "subtitle": "This is one of the few places in the area with a pool." },
+                { "title": "Peace and quiet" }
+              ]
+            }
+          }
+        }
+      }]
+    ]
+  },
+
+  "amenitiesOnly": {
+    "_comment": "Highlights have moved or vanished, amenities are fine. Partial extraction must still return the amenities.",
+    "niobeClientData": [
+      ["StaysPdpSectionsQuery", {
+        "data": {
+          "node": {
+            "pdpPresentation": {
+              "amenities": {
+                "title": "What this place offers",
+                "seeAllAmenitiesGroups": [
+                  {
+                    "title": "Heating and cooling",
+                    "amenities": [{ "available": true, "title": "AC - split type ductless system" }]
+                  }
+                ]
+              },
+              "highlights": null
+            }
+          }
+        }
+      }]
+    ]
+  },
+
+  "partiallyMalformedGroups": {
+    "_comment": "One amenity group is garbage. The healthy groups around it must survive.",
+    "niobeClientData": [
+      ["StaysPdpSectionsQuery", {
+        "data": {
+          "node": {
+            "pdpPresentation": {
+              "amenities": {
+                "seeAllAmenitiesGroups": [
+                  { "title": "Bathroom", "amenities": [{ "available": true, "title": "Hair dryer" }] },
+                  { "title": "Broken group", "amenities": "this should be an array" },
+                  { "title": "Kitchen", "amenities": [{ "available": true, "title": "Oven" }] }
+                ]
+              }
+            }
+          }
+        }
+      }]
+    ]
+  },
+
+  "noPdpBranch": {
+    "_comment": "Airbnb moved the branch again. Extraction must return null, not throw.",
+    "niobeClientData": [["StaysPdpSectionsQuery", { "data": { "presentation": {} } }]]
+  },
+
+  "subtitleShapes": {
+    "_comment": "Airbnb has shipped amenity and highlight subtitles as both a plain string and a { text } object. Both shapes must produce the same label.",
+    "niobeClientData": [
+      ["StaysPdpSectionsQuery", {
+        "data": {
+          "node": {
+            "pdpPresentation": {
+              "amenities": {
+                "seeAllAmenitiesGroups": [
+                  {
+                    "title": "Bathroom",
+                    "amenities": [
+                      { "available": true, "title": "Shampoo", "subtitle": "Body wash" },
+                      { "available": true, "title": "Hair dryer", "subtitle": { "text": "1200W" } }
+                    ]
+                  }
+                ]
+              },
+              "highlights": [
+                { "title": "Great location", "subtitle": "Walk to the beach" },
+                { "title": "Self check-in", "subtitle": { "text": "Check yourself in with the keypad." } }
+              ]
+            }
+          }
+        }
+      }]
+    ]
+  }
+}

--- a/test/fixtures/pdp-presentation.json
+++ b/test/fixtures/pdp-presentation.json
@@ -7,6 +7,9 @@
       ["StaysPdpReviewsQuery", {
         "data": {
           "node": {
+            "location": {
+              "coordinate": { "latitude": 45.3535, "longitude": -121.9452 }
+            },
             "pdpPresentation": {
               "amenities": {
                 "title": "What this place offers",
@@ -88,6 +91,18 @@
   "noPdpBranch": {
     "_comment": "Airbnb moved the branch again. Extraction must return null, not throw.",
     "niobeClientData": [["StaysPdpSectionsQuery", { "data": { "presentation": {} } }]]
+  },
+
+  "locationStubbed": {
+    "_comment": "node.location is present but carries no coordinate - the same client-side-rendering stub that hits amenities/highlights.",
+    "niobeClientData": [
+      ["StaysPdpSectionsQuery", { "data": { "node": { "location": {} } } }]
+    ]
+  },
+
+  "noLocationBranch": {
+    "_comment": "Airbnb moved the location branch entirely. Recovery must return null, not throw.",
+    "niobeClientData": [["StaysPdpSectionsQuery", { "data": { "node": {} } }]]
   },
 
   "subtitleShapes": {

--- a/test/pdp.test.mjs
+++ b/test/pdp.test.mjs
@@ -1,0 +1,213 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import {
+  findPdpPresentation,
+  extractAmenities,
+  extractHighlights,
+  keyAmenityGroups,
+} from "../dist/util.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const fx = JSON.parse(
+  readFileSync(join(__dirname, "fixtures", "pdp-presentation.json"), "utf8")
+);
+
+test("findPdpPresentation locates the branch without hardcoding an index", () => {
+  assert.ok(findPdpPresentation(fx.healthy));
+  assert.equal(findPdpPresentation(fx.noPdpBranch), null);
+  assert.equal(findPdpPresentation({}), null);
+  assert.equal(findPdpPresentation(null), null);
+});
+
+test("extractAmenities passes through the section title", () => {
+  const out = extractAmenities(findPdpPresentation(fx.healthy));
+  assert.equal(out.title, "What this place offers");
+});
+
+test("an all-unavailable group is left unmarked; its title carries the meaning", () => {
+  const out = extractAmenities(findPdpPresentation(fx.healthy));
+  const heat = out.seeAllAmenitiesGroups.find((g) => g.title === "Heating and cooling");
+  const not = out.seeAllAmenitiesGroups.find((g) => g.title === "Not included");
+  assert.deepEqual(heat.amenities, ["Central air conditioning", "Ceiling fan"]);
+  // available:false is how Airbnb renders a struck-through amenity. The mechanism
+  // is availability homogeneity, not the group's title: a group where every item
+  // shares the same availability is left unmarked because the group's own name -
+  // whatever it is - already tells the story. Only a group mixing available and
+  // unavailable items needs its unavailable items called out individually. This
+  // fixture's homogeneous group happens to be titled "Not included", but that
+  // title is not what triggers the behavior - see the next test.
+  assert.deepEqual(not.amenities, ["Dryer", "Hot water"]);
+});
+
+test("a homogeneously-unavailable group is left unmarked under any title, not just 'Not included'", () => {
+  const pdp = {
+    amenities: {
+      seeAllAmenitiesGroups: [
+        {
+          title: "Kitchen extras",
+          amenities: [
+            { title: "Wine glasses", available: false },
+            { title: "Coffee maker", available: false },
+          ],
+        },
+      ],
+    },
+  };
+  const out = extractAmenities(pdp);
+  assert.deepEqual(out.seeAllAmenitiesGroups[0].amenities, ["Wine glasses", "Coffee maker"]);
+});
+
+test("a group mixing available and unavailable items marks the unavailable ones", () => {
+  const pdp = {
+    amenities: {
+      seeAllAmenitiesGroups: [
+        {
+          title: "Laundry",
+          amenities: [
+            { title: "Washer", available: true },
+            { title: "Dryer", available: false },
+          ],
+        },
+      ],
+    },
+  };
+  const out = extractAmenities(pdp);
+  assert.deepEqual(out.seeAllAmenitiesGroups[0].amenities, [
+    "Washer",
+    "Dryer — unavailable",
+  ]);
+});
+
+test("extractHighlights joins a subtitle onto its title when present", () => {
+  const out = extractHighlights(findPdpPresentation(fx.healthy));
+  assert.deepEqual(out.highlights, [
+    "Dive right in: This is one of the few places in the area with a pool.",
+    "Peace and quiet",
+  ]);
+});
+
+// --- partial extraction: one field failing must not cost the others ---
+
+test("amenities still extract when highlights are gone", () => {
+  const pdp = findPdpPresentation(fx.amenitiesOnly);
+  const amenities = extractAmenities(pdp);
+  assert.ok(amenities, "amenities must survive a missing highlights field");
+  assert.deepEqual(amenities.seeAllAmenitiesGroups[0].amenities, [
+    "AC - split type ductless system",
+  ]);
+  assert.equal(extractHighlights(pdp), null, "missing highlights report as null, not as an error");
+});
+
+test("a malformed amenity group does not destroy the healthy groups around it", () => {
+  const out = extractAmenities(findPdpPresentation(fx.partiallyMalformedGroups));
+  const titles = out.seeAllAmenitiesGroups.map((g) => g.title);
+  assert.ok(titles.includes("Bathroom"), "groups before the bad one must survive");
+  assert.ok(titles.includes("Kitchen"), "groups after the bad one must survive");
+  const bathroom = out.seeAllAmenitiesGroups.find((g) => g.title === "Bathroom");
+  assert.deepEqual(bathroom.amenities, ["Hair dryer"]);
+});
+
+test("extraction returns null rather than throwing when the branch moves", () => {
+  assert.equal(extractAmenities(null), null);
+  assert.equal(extractAmenities({}), null);
+  assert.equal(extractHighlights(null), null);
+  assert.equal(extractHighlights({}), null);
+});
+
+test("extractAmenities returns null when every group is empty", () => {
+  const pdp = {
+    amenities: {
+      seeAllAmenitiesGroups: [
+        { title: "Bathroom", amenities: [] },
+        { title: "Kitchen", amenities: [] },
+      ],
+    },
+  };
+  assert.equal(extractAmenities(pdp), null);
+});
+
+// --- subtitle shape: Airbnb has shipped this as both a plain string and a
+// { text } object, on both amenities and highlights. Both must label the same. ---
+
+test("extractAmenities labels a string subtitle and a { text } subtitle identically", () => {
+  const pdp = findPdpPresentation(fx.subtitleShapes);
+  const out = extractAmenities(pdp);
+  assert.deepEqual(out.seeAllAmenitiesGroups[0].amenities, [
+    "Shampoo (Body wash)",
+    "Hair dryer (1200W)",
+  ]);
+});
+
+test("extractHighlights labels a string subtitle and a { text } subtitle identically", () => {
+  const pdp = findPdpPresentation(fx.subtitleShapes);
+  const out = extractHighlights(pdp);
+  assert.deepEqual(out.highlights, [
+    "Great location: Walk to the beach",
+    "Self check-in: Check yourself in with the keypad.",
+  ]);
+});
+
+// --- keyAmenityGroups: no coverage at all before this branch ---
+
+test("keyAmenityGroups keys groups by title", () => {
+  const section = {
+    seeAllAmenitiesGroups: [
+      { title: "Bathroom", amenities: [{ title: "Hair dryer" }] },
+      { title: "Kitchen", amenities: [{ title: "Oven" }] },
+    ],
+  };
+  const out = keyAmenityGroups(section);
+  assert.deepEqual(out.seeAllAmenitiesGroups, {
+    Bathroom: [{ title: "Hair dryer" }],
+    Kitchen: [{ title: "Oven" }],
+  });
+});
+
+test("keyAmenityGroups falls back to 'Other' for an untitled group", () => {
+  const section = {
+    seeAllAmenitiesGroups: [{ amenities: [{ title: "Mystery item" }] }],
+  };
+  const out = keyAmenityGroups(section);
+  assert.deepEqual(out.seeAllAmenitiesGroups, { Other: [{ title: "Mystery item" }] });
+});
+
+test("keyAmenityGroups merges duplicate titles by concatenation, not overwrite", () => {
+  const section = {
+    seeAllAmenitiesGroups: [
+      { title: "Bathroom", amenities: [{ title: "Hair dryer" }] },
+      { title: "Bathroom", amenities: [{ title: "Shampoo" }] },
+    ],
+  };
+  const out = keyAmenityGroups(section);
+  assert.deepEqual(out.seeAllAmenitiesGroups.Bathroom, [
+    { title: "Hair dryer" },
+    { title: "Shampoo" },
+  ]);
+});
+
+test("keyAmenityGroups drops groups that have no amenities", () => {
+  const section = {
+    seeAllAmenitiesGroups: [
+      { title: "Bathroom", amenities: [] },
+      { title: "Kitchen", amenities: [{ title: "Oven" }] },
+    ],
+  };
+  const out = keyAmenityGroups(section);
+  assert.deepEqual(out.seeAllAmenitiesGroups, { Kitchen: [{ title: "Oven" }] });
+  assert.ok(!("Bathroom" in out.seeAllAmenitiesGroups));
+});
+
+test("keyAmenityGroups passes through non-matching objects, arrays, and null unchanged", () => {
+  assert.equal(keyAmenityGroups(null), null);
+  assert.equal(keyAmenityGroups(42), 42);
+
+  const arr = [1, 2, 3];
+  assert.equal(keyAmenityGroups(arr), arr);
+
+  const noGroups = { foo: "bar" };
+  assert.deepEqual(keyAmenityGroups(noGroups), noGroups);
+});

--- a/test/pdp.test.mjs
+++ b/test/pdp.test.mjs
@@ -9,6 +9,9 @@ import {
   extractAmenities,
   extractHighlights,
   keyAmenityGroups,
+  findNodeLocation,
+  extractLocationCoordinate,
+  recoverLocationSection,
 } from "../dist/util.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -210,4 +213,71 @@ test("keyAmenityGroups passes through non-matching objects, arrays, and null unc
 
   const noGroups = { foo: "bar" };
   assert.deepEqual(keyAmenityGroups(noGroups), noGroups);
+});
+
+// --- LOCATION_DEFAULT recovery: same silent-failure mode PR #42 fixed for
+// amenities/highlights, but LOCATION_DEFAULT recovers from node.location, a
+// sibling of node.pdpPresentation, rather than from pdpPresentation itself. ---
+
+test("findNodeLocation locates node.location without hardcoding an index", () => {
+  assert.ok(findNodeLocation(fx.healthy));
+  assert.equal(findNodeLocation(fx.noLocationBranch), null);
+  assert.equal(findNodeLocation({}), null);
+  assert.equal(findNodeLocation(null), null);
+});
+
+test("extractLocationCoordinate reads a real lat/lng off the node", () => {
+  const out = extractLocationCoordinate(findNodeLocation(fx.healthy));
+  assert.deepEqual(out, { lat: 45.3535, lng: -121.9452 });
+});
+
+test("extractLocationCoordinate returns null rather than a fabricated pair when stubbed", () => {
+  assert.equal(extractLocationCoordinate(findNodeLocation(fx.locationStubbed)), null);
+  assert.equal(extractLocationCoordinate(findNodeLocation(fx.noLocationBranch)), null);
+  assert.equal(extractLocationCoordinate(null), null);
+  assert.equal(extractLocationCoordinate({}), null);
+});
+
+test("extractLocationCoordinate rejects a half-formed pair (only one of lat/lng present)", () => {
+  assert.equal(extractLocationCoordinate({ coordinate: { latitude: 45.3535 } }), null);
+  assert.equal(extractLocationCoordinate({ coordinate: { longitude: -121.9452 } }), null);
+});
+
+test("recoverLocationSection passes a section with valid lat/lng through untouched", () => {
+  const sections = [{ id: "LOCATION_DEFAULT", lat: 1, lng: 2, title: "Where you'll be" }];
+  const out = recoverLocationSection(sections, { lat: 45.3535, lng: -121.9452 });
+  assert.deepEqual(out, sections);
+  assert.notEqual(out[0].lat, 45.3535, "present-and-valid values must win over recovery");
+});
+
+test("recoverLocationSection fills in a stubbed LOCATION_DEFAULT section from the recovered coordinate", () => {
+  const sections = [{ id: "LOCATION_DEFAULT" }];
+  const out = recoverLocationSection(sections, { lat: 45.3535, lng: -121.9452 });
+  assert.equal(out.length, 1);
+  assert.deepEqual(out[0], { id: "LOCATION_DEFAULT", lat: 45.3535, lng: -121.9452 });
+});
+
+test("recoverLocationSection adds LOCATION_DEFAULT when the section is absent entirely", () => {
+  const sections = [{ id: "AMENITIES_DEFAULT" }];
+  const out = recoverLocationSection(sections, { lat: 45.3535, lng: -121.9452 });
+  assert.equal(out.length, 2);
+  const loc = out.find((s) => s.id === "LOCATION_DEFAULT");
+  assert.deepEqual(loc, { id: "LOCATION_DEFAULT", lat: 45.3535, lng: -121.9452 });
+});
+
+test("recoverLocationSection changes nothing when neither source has coordinates", () => {
+  const sections = [{ id: "LOCATION_DEFAULT" }];
+  const out = recoverLocationSection(sections, null);
+  assert.deepEqual(out, sections);
+  assert.ok(!("lat" in out[0]), "must omit lat rather than fabricate one");
+  assert.ok(!("lng" in out[0]), "must omit lng rather than fabricate one");
+});
+
+test("rejects NaN and Infinity coordinates and recovers a NaN-carrying stub", () => {
+  assert.equal(extractLocationCoordinate({ coordinate: { latitude: NaN, longitude: -121.9452 } }), null);
+  assert.equal(extractLocationCoordinate({ coordinate: { latitude: 45.3535, longitude: Infinity } }), null);
+
+  const sections = [{ id: "LOCATION_DEFAULT", lat: NaN, lng: -121.9452 }];
+  const out = recoverLocationSection(sections, { lat: 45.3535, lng: -121.9452 });
+  assert.deepEqual(out, [{ id: "LOCATION_DEFAULT", lat: 45.3535, lng: -121.9452 }]);
 });

--- a/test/util.test.mjs
+++ b/test/util.test.mjs
@@ -1,0 +1,38 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { cleanObject, pickBySchema, flattenArraysInObject } from "../dist/util.js";
+
+// The helpers amenity/highlight recovery is built on had no coverage at all.
+
+test("pickBySchema copies only the keys the schema names", () => {
+  const out = pickBySchema({ a: 1, b: 2, c: { d: 3, e: 4 } }, { a: true, c: { d: true } });
+  assert.deepEqual(out, { a: 1, c: { d: 3 } });
+});
+
+test("pickBySchema maps over arrays", () => {
+  const out = pickBySchema([{ a: 1, b: 2 }, { a: 3, b: 4 }], { a: true });
+  assert.deepEqual(out, [{ a: 1 }, { a: 3 }]);
+});
+
+test("pickBySchema returns an empty object when the source is empty", () => {
+  // This is why a stubbed section reads as "no data" rather than "extraction broke".
+  assert.deepEqual(pickBySchema({}, { a: true }), {});
+});
+
+test("cleanObject removes nulls and __typename in place", () => {
+  const o = { a: 1, b: null, __typename: "X", c: { d: null, __typename: "Y", e: 2 } };
+  cleanObject(o);
+  assert.deepEqual(o, { a: 1, c: { e: 2 } });
+});
+
+test("flattenArraysInObject joins arrays of objects into a string", () => {
+  assert.equal(
+    flattenArraysInObject({ items: [{ title: "a" }, { title: "b" }] }).items,
+    "a, b"
+  );
+});
+
+test("flattenArraysInObject leaves primitives alone", () => {
+  assert.deepEqual(flattenArraysInObject({ a: 1, b: "x" }), { a: 1, b: "x" });
+});

--- a/util.ts
+++ b/util.ts
@@ -99,6 +99,67 @@ export function findPdpPresentation(clientData: any): any | null {
 }
 
 /**
+ * Airbnb also stubs LOCATION_DEFAULT under the same client-side-rendering move that
+ * hits AMENITIES_DEFAULT and HIGHLIGHTS_DEFAULT — sectionContentStatus COMPLETE, but
+ * the section carries no coordinates. Unlike those two, LOCATION_DEFAULT's recovery
+ * source is not `pdpPresentation` — it's a sibling branch of the same node:
+ *
+ *   niobeClientData[i][1].data.node.location
+ *
+ * Mirrors findPdpPresentation exactly (same loop, same "don't hardcode the index"
+ * reasoning), just pointed at a different field of the same node.
+ */
+export function findNodeLocation(clientData: any): any | null {
+  const entries = clientData?.niobeClientData;
+  if (!Array.isArray(entries)) return null;
+  for (const entry of entries) {
+    const location = entry?.[1]?.data?.node?.location;
+    if (location && typeof location === "object") return location;
+  }
+  return null;
+}
+
+/**
+ * Pull {lat, lng} off a `location` node. Both coordinates must be present and
+ * numeric — a lone lat or lng is not a usable location, and emitting a half-formed
+ * pair would let a caller mistake it for a real one. Returns null rather than
+ * fabricating a value when the branch is stubbed, empty, or absent.
+ */
+export function extractLocationCoordinate(location: any): { lat: number; lng: number } | null {
+  const lat = location?.coordinate?.latitude;
+  const lng = location?.coordinate?.longitude;
+  return Number.isFinite(lat) && Number.isFinite(lng) ? { lat, lng } : null;
+}
+
+/**
+ * Apply the recovered coordinate to LOCATION_DEFAULT, following the same
+ * replace-the-stub / add-if-absent shape as the fromPdp recovery in
+ * handleAirbnbListingDetails. A section that already carries valid lat/lng passes
+ * through untouched — present-and-valid values always win over recovery. When
+ * `coordinate` is null (recovery found nothing either), the sections are returned
+ * unchanged rather than stripped or fabricated.
+ */
+export function recoverLocationSection(sections: any[], coordinate: { lat: number; lng: number } | null): any[] {
+  if (!coordinate) return sections;
+
+  const hasCoords = (section: any) =>
+    Number.isFinite(section?.lat) && Number.isFinite(section?.lng);
+
+  let found = false;
+  const result = sections.map((section: any) => {
+    if (section?.id !== "LOCATION_DEFAULT") return section;
+    found = true;
+    if (hasCoords(section)) return section;
+    return { id: section.id, ...coordinate };
+  });
+
+  if (!found) {
+    result.push({ id: "LOCATION_DEFAULT", ...coordinate });
+  }
+  return result;
+}
+
+/**
  * Amenity groups, preserving each item's `available` flag.
  *
  * The flag is the whole point: Airbnb renders unavailable amenities struck through,


### PR DESCRIPTION
Closes #46.

`LOCATION_DEFAULT` now ships from Airbnb as a stub in the section tree — the entry
reports `sectionContentStatus: COMPLETE` but carries no coordinates. Today that
returns as a success with an empty location, so a consumer has no way to tell "no
coordinates" from "coordinates not recovered".

This PR recovers the coordinates from the sibling `node.location` branch of the
niobe payload, the same recovery pattern #42 established for amenities:

- `findNodeLocation` / `extractLocationCoordinate` / `recoverLocationSection` in
  `util.ts` locate the coordinate pair and fill the stubbed section.
- The handler only reports `LOCATION_DEFAULT` as recovered when the section was
  actually missing coordinates before the fill.
- Coordinate validity is gated with `Number.isFinite`, so a stub carrying
  `NaN`/`Infinity` (which `typeof === "number"` would accept, and which JSON
  serializes to `null`) is treated as missing and recovered rather than passed
  through as silently-empty coordinates.

## Tests

- 9 new fixture-driven cases in `test/pdp.test.mjs` (32 total pass): happy path,
  stubbed section, absent branch, half-formed pairs, malformed lat/lng, and an
  explicit NaN/Infinity rejection + NaN-stub recovery case.
- Red-proof: with the recovery reverted and tests kept, the new cases fail with the
  reported symptom (empty coordinates on a stubbed section).

Stacked on #52: the diff includes its test-infrastructure commits until #52 merges;
the feature itself is the top commit.
