### PR TITLE
feat: expose the photo tour in airbnb_listing_details

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,11 +244,18 @@ npm run watch
 ### Testing
 
 ```bash
-# Build, then run both suites
+# Build, then run the offline suite
 npm test
 ```
 
-`npm test` drives the built server over stdio and calls the tools for real:
+`npm test` runs the fixture-backed unit suite under `test/*.test.mjs` — no network access, safe for CI and for every install.
+
+```bash
+# Build, then drive the built server over stdio against the real site
+npm run test:live
+```
+
+`npm run test:live` calls the tools for real:
 
 - `test-extension.js` — MCP handshake, tool listing, a search, listing details, and the geocoding paths (Photon, Nominatim fallback)
 - `test-amenities.js` — amenity extraction across several live listings, checking that amenities Airbnb strikes through never appear as ones the listing offers

--- a/index.ts
+++ b/index.ts
@@ -11,7 +11,7 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 import fetch from "node-fetch";
 import * as cheerio from "cheerio";
-import { cleanObject, flattenArraysInObject, pickBySchema, diagnoseJsonPath, findPdpPresentation, extractAmenities, extractHighlights, keyAmenityGroups } from "./util.js";
+import { cleanObject, flattenArraysInObject, pickBySchema, diagnoseJsonPath, findPdpPresentation, extractAmenities, extractHighlights, keyAmenityGroups, extractMediaTour } from "./util.js";
 import robotsParser from "robots-parser";
 import { readFileSync } from 'fs';
 import { fileURLToPath } from 'url';
@@ -787,6 +787,23 @@ async function handleAirbnbListingDetails(params: any) {
             extracted.push({ id: sectionId, ...flattenArraysInObject(keyAmenityGroups(replacement.value)) });
           }
         }
+      }
+
+      // Photo tour: mediaTour, sleepingArrangements, and bathroomsTour are three
+      // sibling keys under pdpPresentation sharing one MediaTour shape. Unlike
+      // AMENITIES_DEFAULT/HIGHLIGHTS_DEFAULT above, none of these
+      // ever appear as a stubbed entry in the sections list - they are additive,
+      // not a stub to replace. The per-room amenity list is the primary payload
+      // (see extractMediaTour's docstring): it is what lets a caller catch a
+      // listing that claims N bedrooms while one "bedroom" stop is really a den.
+      const photoTourSections: Array<[string, any]> = [
+        ["PHOTO_TOUR", pdp?.mediaTour],
+        ["SLEEPING_ARRANGEMENTS_TOUR", pdp?.sleepingArrangements],
+        ["BATHROOMS_TOUR", pdp?.bathroomsTour],
+      ];
+      for (const [id, tour] of photoTourSections) {
+        const value = extractMediaTour(tour);
+        if (value) extracted.push({ id, ...value });
       }
 
       details = extracted;

--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
     "prepare": "npm run build",
     "version": "node sync-version.js && git add manifest.json",
     "pretest": "npm run build",
-    "test": "node test-extension.js && node test-amenities.js",
+    "test": "node --test test/*.test.mjs",
+    "pretest:live": "npm run build",
+    "test:live": "node test-extension.js && node test-amenities.js",
     "watch": "tsc --watch",
     "sync-version": "node sync-version.js"
   },

--- a/test-amenities.js
+++ b/test-amenities.js
@@ -13,7 +13,10 @@ function call(id) {
       stdio: ["pipe", "pipe", "pipe"],
     });
     let buf = "";
+    let toolCallSent = false;
     const timer = setTimeout(() => { proc.kill(); reject(new Error("timeout")); }, 60000);
+
+    const send = (o) => proc.stdin.write(JSON.stringify(o) + "\n");
 
     proc.stdout.on("data", (d) => {
       buf += d.toString();
@@ -21,23 +24,36 @@ function call(id) {
         if (!line.trim().startsWith("{")) continue;
         let msg;
         try { msg = JSON.parse(line); } catch { continue; }
+
+        // The id-1 reply, not a fixed sleep, is what says the server is ready.
+        if (msg.id === 1 && !toolCallSent) {
+          toolCallSent = true;
+          send({ jsonrpc: "2.0", method: "notifications/initialized" });
+          send({ jsonrpc: "2.0", id: 2, method: "tools/call", params: {
+            name: "airbnb_listing_details", arguments: { id, ignoreRobotsText: true } } });
+          continue;
+        }
+
         if (msg.id === 2) {
           clearTimeout(timer);
           proc.kill();
-          resolve(JSON.parse(msg.result.content[0].text));
+          if (msg.error) {
+            reject(new Error(`JSON-RPC error: ${JSON.stringify(msg.error)}`));
+            return;
+          }
+          const text = msg.result?.content?.[0]?.text;
+          if (!text) {
+            reject(new Error(`malformed tools/call response: ${JSON.stringify(msg)}`));
+            return;
+          }
+          resolve(JSON.parse(text));
         }
       }
     });
     proc.on("error", reject);
 
-    const send = (o) => proc.stdin.write(JSON.stringify(o) + "\n");
     send({ jsonrpc: "2.0", id: 1, method: "initialize", params: {
       protocolVersion: "2024-11-05", capabilities: {}, clientInfo: { name: "t", version: "1" } } });
-    setTimeout(() => {
-      send({ jsonrpc: "2.0", method: "notifications/initialized" });
-      send({ jsonrpc: "2.0", id: 2, method: "tools/call", params: {
-        name: "airbnb_listing_details", arguments: { id, ignoreRobotsText: true } } });
-    }, 700);
   });
 }
 

--- a/test-extension.js
+++ b/test-extension.js
@@ -24,7 +24,7 @@ class MCPTester {
 
   async startServer() {
     console.log('🚀 Starting MCP server...');
-    
+
     this.server = spawn('node', [SERVER_PATH, '--ignore-robots-txt'], {
       stdio: ['pipe', 'pipe', 'pipe'],
       env: { ...process.env, IGNORE_ROBOTS_TXT: 'true' }
@@ -34,13 +34,21 @@ class MCPTester {
       console.log('📋 Server log:', data.toString().trim());
     });
 
-    // Wait for server to start
-    await new Promise(resolve => setTimeout(resolve, 2000));
-    
     if (this.server.killed) {
       throw new Error('Server failed to start');
     }
-    
+
+    // Await the real initialize response instead of a fixed sleep.
+    const initResponse = await this.sendRequest('initialize', {
+      protocolVersion: '2024-11-05',
+      capabilities: {},
+      clientInfo: { name: 'test-extension', version: '1' },
+    });
+    if (initResponse.error) {
+      throw new Error(`initialize failed: ${initResponse.error.message}`);
+    }
+    this.server.stdin.write(JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' }) + '\n');
+
     console.log('✅ Server started successfully');
   }
 
@@ -260,6 +268,11 @@ class MCPTester {
           name: 'airbnb_search',
           arguments: { location: c.location, ignoreRobotsText: true },
         });
+        if (response.error) {
+          console.log(`   ❌ ${c.label}: JSON-RPC error: ${response.error.message || JSON.stringify(response.error)}`);
+          allOk = false;
+          continue;
+        }
         const url = this._extractSearchUrl(response);
         const bbox = parseBbox(url);
         if (!bbox) {

--- a/test/fixtures/pdp-presentation.json
+++ b/test/fixtures/pdp-presentation.json
@@ -117,5 +117,366 @@
         }
       }]
     ]
+  },
+
+  "photoTour": {
+    "_comment": "Trimmed from the real payload for listing 1576852203737322823 (fetched 2026-07-28). This is the real-world discriminator: Bedroom 5 is missing the Clothing storage / Hangers / Essentials / Room-darkening shades amenities that Bedrooms 1-4 all carry, while the separate Game room stop lists Bed linens. An earlier photo-reuse hypothesis was disproved (zero image-id overlap between Bedroom 5 and Game room) - the signal lives in the per-room amenity lists and stop names, not the photos.",
+    "niobeClientData": [
+      [null, {
+        "data": {
+          "node": {
+            "pdpPresentation": {
+              "mediaTour": {
+                "__typename": "MediaTour",
+                "name": "Photo tour",
+                "stops": [
+                  {
+                    "__typename": "MediaTourStop",
+                    "id": "1576852203737322823-space-757596962",
+                    "name": "Living room",
+                    "items": [
+                      { "image": { "caption": null, "imageId": "1" } },
+                      { "image": { "caption": null, "imageId": "2" } }
+                    ],
+                    "description": {
+                      "descriptions": [
+                        { "text": "Books and reading material" },
+                        { "text": "Air conditioning" },
+                        { "text": "Heating" },
+                        { "text": "Indoor fireplace" },
+                        { "text": "Sound system" },
+                        { "text": "TV" }
+                      ]
+                    }
+                  },
+                  {
+                    "__typename": "MediaTourStop",
+                    "id": "1576852203737322823-space-757489378",
+                    "name": "Bedroom 1",
+                    "items": [
+                      {
+                        "image": {
+                          "caption": {
+                            "__typename": "MediaText",
+                            "user": {
+                              "localizedStringWithTranslationPreference": "Master bedroom with king bed and attached master bathroom on main level",
+                              "localizedString": "Master bedroom with king bed and attached master bathroom on main level"
+                            }
+                          },
+                          "imageId": "2442336944"
+                        }
+                      },
+                      { "image": { "caption": null, "imageId": "2442337239" } }
+                    ],
+                    "description": {
+                      "descriptions": [
+                        { "text": "King bed" },
+                        { "text": "Bed linens" },
+                        { "text": "Clothing storage" },
+                        { "text": "Essentials" },
+                        { "text": "Extra pillows and blankets" },
+                        { "text": "Hangers" },
+                        { "text": "Heating" },
+                        { "text": "Room-darkening shades" }
+                      ]
+                    }
+                  },
+                  {
+                    "__typename": "MediaTourStop",
+                    "id": "1576852203737322823-space-757489379",
+                    "name": "Bedroom 2",
+                    "items": [
+                      { "image": { "caption": { "user": { "localizedStringWithTranslationPreference": "King bedroom on main level" } }, "imageId": "2442337446" } },
+                      { "image": { "caption": null, "imageId": "2442337447" } }
+                    ],
+                    "description": {
+                      "descriptions": [
+                        { "text": "King bed" },
+                        { "text": "Air conditioning" },
+                        { "text": "Bed linens" },
+                        { "text": "Clothing storage" },
+                        { "text": "Essentials" },
+                        { "text": "Extra pillows and blankets" },
+                        { "text": "Hangers" },
+                        { "text": "Heating" },
+                        { "text": "Room-darkening shades" }
+                      ]
+                    }
+                  },
+                  {
+                    "__typename": "MediaTourStop",
+                    "id": "1576852203737322823-space-757489380",
+                    "name": "Bedroom 3",
+                    "items": [
+                      { "image": { "caption": { "user": { "localizedStringWithTranslationPreference": "King bedroom on main level" } }, "imageId": "2442337500" } }
+                    ],
+                    "description": {
+                      "descriptions": [
+                        { "text": "King bed" },
+                        { "text": "Air conditioning" },
+                        { "text": "Bed linens" },
+                        { "text": "Clothing storage" },
+                        { "text": "Essentials" },
+                        { "text": "Extra pillows and blankets" },
+                        { "text": "Hangers" },
+                        { "text": "Heating" },
+                        { "text": "Room-darkening shades" }
+                      ]
+                    }
+                  },
+                  {
+                    "__typename": "MediaTourStop",
+                    "id": "1576852203737322823-space-757489381",
+                    "name": "Bedroom 4",
+                    "items": [
+                      { "image": { "caption": { "user": { "localizedStringWithTranslationPreference": "Queen bedroom downstairs with third bathroom on same level" } }, "imageId": "2442337600" } }
+                    ],
+                    "description": {
+                      "descriptions": [
+                        { "text": "Queen bed" },
+                        { "text": "Air conditioning" },
+                        { "text": "Bed linens" },
+                        { "text": "Clothing storage" },
+                        { "text": "Essentials" },
+                        { "text": "Extra pillows and blankets" },
+                        { "text": "Hangers" },
+                        { "text": "Heating" },
+                        { "text": "Room-darkening shades" }
+                      ]
+                    }
+                  },
+                  {
+                    "__typename": "MediaTourStop",
+                    "id": "1576852203737322823-space-771388337",
+                    "name": "Bedroom 5",
+                    "items": [
+                      { "image": { "caption": null, "imageId": "9001" } },
+                      { "image": { "caption": null, "imageId": "9002" } },
+                      { "image": { "caption": null, "imageId": "9003" } }
+                    ],
+                    "description": {
+                      "descriptions": [
+                        { "text": "2 single beds" },
+                        { "text": "Air conditioning" },
+                        { "text": "Bed linens" },
+                        { "text": "Extra pillows and blankets" },
+                        { "text": "Heating" },
+                        { "text": "TV" }
+                      ]
+                    }
+                  },
+                  {
+                    "__typename": "MediaTourStop",
+                    "id": "1576852203737322823-space-771375265",
+                    "name": "Game room",
+                    "items": [
+                      { "image": { "caption": null, "imageId": "9101" } },
+                      { "image": { "caption": null, "imageId": "9102" } },
+                      { "image": { "caption": null, "imageId": "9103" } }
+                    ],
+                    "description": {
+                      "descriptions": [
+                        { "text": "Air conditioning" },
+                        { "text": "Bed linens" },
+                        { "text": "Board games" },
+                        { "text": "Books and reading material" },
+                        { "text": "Children's books and toys" },
+                        { "text": "Children's playroom" },
+                        { "text": "TV" },
+                        { "text": "Wifi" }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "bathroomsTour": {
+                "__typename": "MediaTour",
+                "name": "What's the bathroom like",
+                "stops": []
+              }
+            }
+          }
+        }
+      }]
+    ]
+  },
+
+  "photoTourCaptionEdgeCases": {
+    "_comment": "One item has a null caption, one has a caption made only of whitespace, one repeats an already-seen caption verbatim, and one falls back to localizedString because localizedStringWithTranslationPreference is absent.",
+    "niobeClientData": [
+      [null, {
+        "data": {
+          "node": {
+            "pdpPresentation": {
+              "mediaTour": {
+                "name": "Photo tour",
+                "stops": [
+                  {
+                    "name": "Kitchen",
+                    "items": [
+                      { "image": { "caption": null, "imageId": "1" } },
+                      { "image": { "caption": { "user": { "localizedStringWithTranslationPreference": "Full kitchen" } }, "imageId": "2" } },
+                      { "image": { "caption": { "user": { "localizedStringWithTranslationPreference": "   " } }, "imageId": "3" } },
+                      { "image": { "caption": { "user": { "localizedStringWithTranslationPreference": "Full kitchen" } }, "imageId": "4" } },
+                      { "image": { "caption": { "user": { "localizedString": "Fallback caption text" } }, "imageId": "5" } }
+                    ]
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }]
+    ]
+  },
+
+  "photoTourDescriptionMissing": {
+    "_comment": "A stop with no description at all - it must still return with name and captions.",
+    "niobeClientData": [
+      [null, {
+        "data": {
+          "node": {
+            "pdpPresentation": {
+              "mediaTour": {
+                "name": "Photo tour",
+                "stops": [
+                  {
+                    "name": "Exterior",
+                    "items": [
+                      { "image": { "caption": { "user": { "localizedStringWithTranslationPreference": "Backyard with hot tub" } }, "imageId": "1" } }
+                    ]
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }]
+    ]
+  },
+
+  "photoTourKeyAbsent": {
+    "_comment": "sleepingArrangements and bathroomsTour are absent entirely; only mediaTour is present. Recovery must omit the absent keys, never throw.",
+    "niobeClientData": [
+      [null, {
+        "data": {
+          "node": {
+            "pdpPresentation": {
+              "mediaTour": {
+                "name": "Photo tour",
+                "stops": [
+                  { "name": "Library", "items": [{ "image": { "caption": null, "imageId": "1" } }] }
+                ]
+              }
+            }
+          }
+        }
+      }]
+    ]
+  },
+
+  "photoTourStopsEmpty": {
+    "_comment": "bathroomsTour is present (as it really is on this listing) but its stops array is empty.",
+    "niobeClientData": [
+      [null, {
+        "data": {
+          "node": {
+            "pdpPresentation": {
+              "bathroomsTour": { "name": "What's the bathroom like", "stops": [] }
+            }
+          }
+        }
+      }]
+    ]
+  },
+
+  "photoTourStopsMissing": {
+    "_comment": "mediaTour is present but the stops key itself is missing (not just empty).",
+    "niobeClientData": [
+      [null, {
+        "data": {
+          "node": {
+            "pdpPresentation": {
+              "mediaTour": { "name": "Photo tour" }
+            }
+          }
+        }
+      }]
+    ]
+  },
+
+  "otherTours": {
+    "niobeClientData": [
+      [null, {
+        "data": {
+          "node": {
+            "pdpPresentation": {
+              "sleepingArrangements": {
+                "name": "Where you'll sleep",
+                "stops": [
+                  {
+                    "name": "Bedroom 1",
+                    "items": [
+                      { "image": { "caption": { "user": { "localizedStringWithTranslationPreference": "King bed" } }, "imageId": "1" } }
+                    ],
+                    "description": {
+                      "descriptions": [
+                        { "text": "King bed" }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "bathroomsTour": {
+                "name": "What's the bathroom like",
+                "stops": [
+                  {
+                    "name": "Bathroom 1",
+                    "items": [
+                      { "image": { "caption": { "user": { "localizedStringWithTranslationPreference": "Shower" } }, "imageId": "2" } }
+                    ],
+                    "description": {
+                      "descriptions": [
+                        { "text": "Hot water" },
+                        { "text": "Shampoo" }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }]
+    ]
+  },
+
+  "photoTourNameMissing": {
+    "_comment": "A stop with no name - asserts name key omitted, captions kept.",
+    "niobeClientData": [
+      [null, {
+        "data": {
+          "node": {
+            "pdpPresentation": {
+              "mediaTour": {
+                "name": "Photo tour",
+                "stops": [
+                  {
+                    "items": [
+                      { "image": { "caption": { "user": { "localizedStringWithTranslationPreference": "A nice room" } }, "imageId": "1" } }
+                    ],
+                    "description": {
+                      "descriptions": [
+                        { "text": "Some amenity" }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }]
+    ]
   }
 }

--- a/test/fixtures/pdp-presentation.json
+++ b/test/fixtures/pdp-presentation.json
@@ -1,0 +1,121 @@
+{
+  "_comment": "Shapes of niobeClientData[i][1].data.node.pdpPresentation. 'healthy' is trimmed from a real listing payload; the others are synthesized to exercise specific edge cases. Real entries carry a string operation-name key at index 0, not null.",
+
+  "healthy": {
+    "niobeClientData": [
+      ["StaysPdpSectionsQuery", { "data": { "presentation": {} } }],
+      ["StaysPdpReviewsQuery", {
+        "data": {
+          "node": {
+            "pdpPresentation": {
+              "amenities": {
+                "title": "What this place offers",
+                "seeAllAmenitiesGroups": [
+                  {
+                    "__typename": "AmenityItemsGroup",
+                    "title": "Heating and cooling",
+                    "amenities": [
+                      { "available": true, "title": "Central air conditioning", "subtitle": { "text": "" } },
+                      { "available": true, "title": "Ceiling fan", "subtitle": { "text": "" } }
+                    ]
+                  },
+                  {
+                    "__typename": "AmenityItemsGroup",
+                    "title": "Not included",
+                    "amenities": [
+                      { "available": false, "title": "Dryer", "subtitle": { "text": "" } },
+                      { "available": false, "title": "Hot water", "subtitle": { "text": "" } }
+                    ]
+                  }
+                ]
+              },
+              "highlights": [
+                { "title": "Dive right in", "subtitle": "This is one of the few places in the area with a pool." },
+                { "title": "Peace and quiet" }
+              ]
+            }
+          }
+        }
+      }]
+    ]
+  },
+
+  "amenitiesOnly": {
+    "_comment": "Highlights have moved or vanished, amenities are fine. Partial extraction must still return the amenities.",
+    "niobeClientData": [
+      ["StaysPdpSectionsQuery", {
+        "data": {
+          "node": {
+            "pdpPresentation": {
+              "amenities": {
+                "title": "What this place offers",
+                "seeAllAmenitiesGroups": [
+                  {
+                    "title": "Heating and cooling",
+                    "amenities": [{ "available": true, "title": "AC - split type ductless system" }]
+                  }
+                ]
+              },
+              "highlights": null
+            }
+          }
+        }
+      }]
+    ]
+  },
+
+  "partiallyMalformedGroups": {
+    "_comment": "One amenity group is garbage. The healthy groups around it must survive.",
+    "niobeClientData": [
+      ["StaysPdpSectionsQuery", {
+        "data": {
+          "node": {
+            "pdpPresentation": {
+              "amenities": {
+                "seeAllAmenitiesGroups": [
+                  { "title": "Bathroom", "amenities": [{ "available": true, "title": "Hair dryer" }] },
+                  { "title": "Broken group", "amenities": "this should be an array" },
+                  { "title": "Kitchen", "amenities": [{ "available": true, "title": "Oven" }] }
+                ]
+              }
+            }
+          }
+        }
+      }]
+    ]
+  },
+
+  "noPdpBranch": {
+    "_comment": "Airbnb moved the branch again. Extraction must return null, not throw.",
+    "niobeClientData": [["StaysPdpSectionsQuery", { "data": { "presentation": {} } }]]
+  },
+
+  "subtitleShapes": {
+    "_comment": "Airbnb has shipped amenity and highlight subtitles as both a plain string and a { text } object. Both shapes must produce the same label.",
+    "niobeClientData": [
+      ["StaysPdpSectionsQuery", {
+        "data": {
+          "node": {
+            "pdpPresentation": {
+              "amenities": {
+                "seeAllAmenitiesGroups": [
+                  {
+                    "title": "Bathroom",
+                    "amenities": [
+                      { "available": true, "title": "Shampoo", "subtitle": "Body wash" },
+                      { "available": true, "title": "Hair dryer", "subtitle": { "text": "1200W" } }
+                    ]
+                  }
+                ]
+              },
+              "highlights": [
+                { "title": "Great location", "subtitle": "Walk to the beach" },
+                { "title": "Self check-in", "subtitle": { "text": "Check yourself in with the keypad." } }
+              ]
+            }
+          }
+        }
+      }]
+    ]
+  }
+}

--- a/test/pdp.test.mjs
+++ b/test/pdp.test.mjs
@@ -1,0 +1,213 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import {
+  findPdpPresentation,
+  extractAmenities,
+  extractHighlights,
+  keyAmenityGroups,
+} from "../dist/util.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const fx = JSON.parse(
+  readFileSync(join(__dirname, "fixtures", "pdp-presentation.json"), "utf8")
+);
+
+test("findPdpPresentation locates the branch without hardcoding an index", () => {
+  assert.ok(findPdpPresentation(fx.healthy));
+  assert.equal(findPdpPresentation(fx.noPdpBranch), null);
+  assert.equal(findPdpPresentation({}), null);
+  assert.equal(findPdpPresentation(null), null);
+});
+
+test("extractAmenities passes through the section title", () => {
+  const out = extractAmenities(findPdpPresentation(fx.healthy));
+  assert.equal(out.title, "What this place offers");
+});
+
+test("an all-unavailable group is left unmarked; its title carries the meaning", () => {
+  const out = extractAmenities(findPdpPresentation(fx.healthy));
+  const heat = out.seeAllAmenitiesGroups.find((g) => g.title === "Heating and cooling");
+  const not = out.seeAllAmenitiesGroups.find((g) => g.title === "Not included");
+  assert.deepEqual(heat.amenities, ["Central air conditioning", "Ceiling fan"]);
+  // available:false is how Airbnb renders a struck-through amenity. The mechanism
+  // is availability homogeneity, not the group's title: a group where every item
+  // shares the same availability is left unmarked because the group's own name -
+  // whatever it is - already tells the story. Only a group mixing available and
+  // unavailable items needs its unavailable items called out individually. This
+  // fixture's homogeneous group happens to be titled "Not included", but that
+  // title is not what triggers the behavior - see the next test.
+  assert.deepEqual(not.amenities, ["Dryer", "Hot water"]);
+});
+
+test("a homogeneously-unavailable group is left unmarked under any title, not just 'Not included'", () => {
+  const pdp = {
+    amenities: {
+      seeAllAmenitiesGroups: [
+        {
+          title: "Kitchen extras",
+          amenities: [
+            { title: "Wine glasses", available: false },
+            { title: "Coffee maker", available: false },
+          ],
+        },
+      ],
+    },
+  };
+  const out = extractAmenities(pdp);
+  assert.deepEqual(out.seeAllAmenitiesGroups[0].amenities, ["Wine glasses", "Coffee maker"]);
+});
+
+test("a group mixing available and unavailable items marks the unavailable ones", () => {
+  const pdp = {
+    amenities: {
+      seeAllAmenitiesGroups: [
+        {
+          title: "Laundry",
+          amenities: [
+            { title: "Washer", available: true },
+            { title: "Dryer", available: false },
+          ],
+        },
+      ],
+    },
+  };
+  const out = extractAmenities(pdp);
+  assert.deepEqual(out.seeAllAmenitiesGroups[0].amenities, [
+    "Washer",
+    "Dryer — unavailable",
+  ]);
+});
+
+test("extractHighlights joins a subtitle onto its title when present", () => {
+  const out = extractHighlights(findPdpPresentation(fx.healthy));
+  assert.deepEqual(out.highlights, [
+    "Dive right in: This is one of the few places in the area with a pool.",
+    "Peace and quiet",
+  ]);
+});
+
+// --- partial extraction: one field failing must not cost the others ---
+
+test("amenities still extract when highlights are gone", () => {
+  const pdp = findPdpPresentation(fx.amenitiesOnly);
+  const amenities = extractAmenities(pdp);
+  assert.ok(amenities, "amenities must survive a missing highlights field");
+  assert.deepEqual(amenities.seeAllAmenitiesGroups[0].amenities, [
+    "AC - split type ductless system",
+  ]);
+  assert.equal(extractHighlights(pdp), null, "missing highlights report as null, not as an error");
+});
+
+test("a malformed amenity group does not destroy the healthy groups around it", () => {
+  const out = extractAmenities(findPdpPresentation(fx.partiallyMalformedGroups));
+  const titles = out.seeAllAmenitiesGroups.map((g) => g.title);
+  assert.ok(titles.includes("Bathroom"), "groups before the bad one must survive");
+  assert.ok(titles.includes("Kitchen"), "groups after the bad one must survive");
+  const bathroom = out.seeAllAmenitiesGroups.find((g) => g.title === "Bathroom");
+  assert.deepEqual(bathroom.amenities, ["Hair dryer"]);
+});
+
+test("extraction returns null rather than throwing when the branch moves", () => {
+  assert.equal(extractAmenities(null), null);
+  assert.equal(extractAmenities({}), null);
+  assert.equal(extractHighlights(null), null);
+  assert.equal(extractHighlights({}), null);
+});
+
+test("extractAmenities returns null when every group is empty", () => {
+  const pdp = {
+    amenities: {
+      seeAllAmenitiesGroups: [
+        { title: "Bathroom", amenities: [] },
+        { title: "Kitchen", amenities: [] },
+      ],
+    },
+  };
+  assert.equal(extractAmenities(pdp), null);
+});
+
+// --- subtitle shape: Airbnb has shipped this as both a plain string and a
+// { text } object, on both amenities and highlights. Both must label the same. ---
+
+test("extractAmenities labels a string subtitle and a { text } subtitle identically", () => {
+  const pdp = findPdpPresentation(fx.subtitleShapes);
+  const out = extractAmenities(pdp);
+  assert.deepEqual(out.seeAllAmenitiesGroups[0].amenities, [
+    "Shampoo (Body wash)",
+    "Hair dryer (1200W)",
+  ]);
+});
+
+test("extractHighlights labels a string subtitle and a { text } subtitle identically", () => {
+  const pdp = findPdpPresentation(fx.subtitleShapes);
+  const out = extractHighlights(pdp);
+  assert.deepEqual(out.highlights, [
+    "Great location: Walk to the beach",
+    "Self check-in: Check yourself in with the keypad.",
+  ]);
+});
+
+// --- keyAmenityGroups: no coverage at all before this branch ---
+
+test("keyAmenityGroups keys groups by title", () => {
+  const section = {
+    seeAllAmenitiesGroups: [
+      { title: "Bathroom", amenities: [{ title: "Hair dryer" }] },
+      { title: "Kitchen", amenities: [{ title: "Oven" }] },
+    ],
+  };
+  const out = keyAmenityGroups(section);
+  assert.deepEqual(out.seeAllAmenitiesGroups, {
+    Bathroom: [{ title: "Hair dryer" }],
+    Kitchen: [{ title: "Oven" }],
+  });
+});
+
+test("keyAmenityGroups falls back to 'Other' for an untitled group", () => {
+  const section = {
+    seeAllAmenitiesGroups: [{ amenities: [{ title: "Mystery item" }] }],
+  };
+  const out = keyAmenityGroups(section);
+  assert.deepEqual(out.seeAllAmenitiesGroups, { Other: [{ title: "Mystery item" }] });
+});
+
+test("keyAmenityGroups merges duplicate titles by concatenation, not overwrite", () => {
+  const section = {
+    seeAllAmenitiesGroups: [
+      { title: "Bathroom", amenities: [{ title: "Hair dryer" }] },
+      { title: "Bathroom", amenities: [{ title: "Shampoo" }] },
+    ],
+  };
+  const out = keyAmenityGroups(section);
+  assert.deepEqual(out.seeAllAmenitiesGroups.Bathroom, [
+    { title: "Hair dryer" },
+    { title: "Shampoo" },
+  ]);
+});
+
+test("keyAmenityGroups drops groups that have no amenities", () => {
+  const section = {
+    seeAllAmenitiesGroups: [
+      { title: "Bathroom", amenities: [] },
+      { title: "Kitchen", amenities: [{ title: "Oven" }] },
+    ],
+  };
+  const out = keyAmenityGroups(section);
+  assert.deepEqual(out.seeAllAmenitiesGroups, { Kitchen: [{ title: "Oven" }] });
+  assert.ok(!("Bathroom" in out.seeAllAmenitiesGroups));
+});
+
+test("keyAmenityGroups passes through non-matching objects, arrays, and null unchanged", () => {
+  assert.equal(keyAmenityGroups(null), null);
+  assert.equal(keyAmenityGroups(42), 42);
+
+  const arr = [1, 2, 3];
+  assert.equal(keyAmenityGroups(arr), arr);
+
+  const noGroups = { foo: "bar" };
+  assert.deepEqual(keyAmenityGroups(noGroups), noGroups);
+});

--- a/test/pdp.test.mjs
+++ b/test/pdp.test.mjs
@@ -9,6 +9,7 @@ import {
   extractAmenities,
   extractHighlights,
   keyAmenityGroups,
+  extractMediaTour,
 } from "../dist/util.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -210,4 +211,134 @@ test("keyAmenityGroups passes through non-matching objects, arrays, and null unc
 
   const noGroups = { foo: "bar" };
   assert.deepEqual(keyAmenityGroups(noGroups), noGroups);
+});
+
+// --- photo tour (mediaTour / sleepingArrangements / bathroomsTour): per-room
+// amenity fingerprint is the primary payload, not the images. A listing can claim
+// N bedrooms while one "bedroom" stop is missing the amenities its peers all carry
+// (Clothing storage, Hangers, Essentials, Room-darkening shades) - that gap is what
+// exposes a capacity-vs-reality mismatch on a group trip. Raw image data (uri,
+// imageId, assetMetadata, tags) is deliberately never emitted: this fork's whole
+// selling point is staying far below stock token cost. ---
+
+test("extractMediaTour returns stop names, deduped captions, and per-room amenities", () => {
+  const pdp = findPdpPresentation(fx.photoTour);
+  const out = extractMediaTour(pdp?.mediaTour);
+  assert.equal(out.sectionTitle, "Photo tour");
+
+  const bedroom1 = out.stops.find((s) => s.name === "Bedroom 1");
+  assert.deepEqual(bedroom1.captions, [
+    "Master bedroom with king bed and attached master bathroom on main level",
+  ]);
+  assert.deepEqual(bedroom1.amenities, [
+    "King bed",
+    "Bed linens",
+    "Clothing storage",
+    "Essentials",
+    "Extra pillows and blankets",
+    "Hangers",
+    "Heating",
+    "Room-darkening shades",
+  ]);
+
+  // Never emit image internals - that's the whole point of the compact shape.
+  const json = JSON.stringify(out);
+  assert.ok(!json.includes("imageId"));
+  assert.ok(!json.includes("assetMetadata"));
+  assert.ok(!json.includes("uri"));
+  assert.ok(!json.includes("tags"));
+});
+
+test("extractMediaTour surfaces the real-world discriminator: Bedroom 5 is missing amenities Bedrooms 1-4 all carry, Game room lists Bed linens", () => {
+  const pdp = findPdpPresentation(fx.photoTour);
+  const out = extractMediaTour(pdp?.mediaTour);
+
+  const b1 = out.stops.find((s) => s.name === "Bedroom 1").amenities;
+  const b2 = out.stops.find((s) => s.name === "Bedroom 2").amenities;
+  const b3 = out.stops.find((s) => s.name === "Bedroom 3").amenities;
+  const b4 = out.stops.find((s) => s.name === "Bedroom 4").amenities;
+  const b5 = out.stops.find((s) => s.name === "Bedroom 5").amenities;
+  const gameRoom = out.stops.find((s) => s.name === "Game room").amenities;
+
+  for (const amenity of ["Clothing storage", "Hangers", "Essentials", "Room-darkening shades"]) {
+    assert.ok(b1.includes(amenity), `Bedroom 1 must list ${amenity}`);
+    assert.ok(b2.includes(amenity), `Bedroom 2 must list ${amenity}`);
+    assert.ok(b3.includes(amenity), `Bedroom 3 must list ${amenity}`);
+    assert.ok(b4.includes(amenity), `Bedroom 4 must list ${amenity}`);
+    assert.ok(!b5.includes(amenity), `Bedroom 5 must NOT list ${amenity} - this is the discriminator`);
+  }
+  assert.ok(gameRoom.includes("Bed linens"), "Game room lists Bed linens despite not being a bedroom stop");
+});
+
+test("extractMediaTour drops null captions but keeps the stop's other captions", () => {
+  const pdp = findPdpPresentation(fx.photoTourCaptionEdgeCases);
+  const out = extractMediaTour(pdp?.mediaTour);
+  const kitchen = out.stops.find((s) => s.name === "Kitchen");
+  // null caption dropped, whitespace-only caption dropped, duplicate "Full kitchen"
+  // deduped, and the last item falls back to localizedString since
+  // localizedStringWithTranslationPreference is absent on it.
+  assert.deepEqual(kitchen.captions, ["Full kitchen", "Fallback caption text"]);
+});
+
+test("extractMediaTour still returns a stop's name and captions when description is missing", () => {
+  const pdp = findPdpPresentation(fx.photoTourDescriptionMissing);
+  const out = extractMediaTour(pdp?.mediaTour);
+  const exterior = out.stops.find((s) => s.name === "Exterior");
+  assert.equal(exterior.name, "Exterior");
+  assert.deepEqual(exterior.captions, ["Backyard with hot tub"]);
+  assert.ok(!("amenities" in exterior), "missing description must omit amenities, never emit null/[]");
+});
+
+test("extractMediaTour returns null when the tour key itself is absent, without throwing", () => {
+  const pdp = findPdpPresentation(fx.photoTourKeyAbsent);
+  assert.ok(extractMediaTour(pdp?.mediaTour), "mediaTour is present on this fixture");
+  assert.equal(extractMediaTour(pdp?.sleepingArrangements), null, "sleepingArrangements is absent");
+  assert.equal(extractMediaTour(pdp?.bathroomsTour), null, "bathroomsTour is absent");
+  assert.equal(extractMediaTour(undefined), null);
+  assert.equal(extractMediaTour(null), null);
+});
+
+test("extractMediaTour returns null when stops is an empty array", () => {
+  const pdp = findPdpPresentation(fx.photoTourStopsEmpty);
+  assert.equal(extractMediaTour(pdp?.bathroomsTour), null);
+});
+
+test("extractMediaTour returns null when stops is missing entirely, without throwing", () => {
+  const pdp = findPdpPresentation(fx.photoTourStopsMissing);
+  assert.doesNotThrow(() => extractMediaTour(pdp?.mediaTour));
+  assert.equal(extractMediaTour(pdp?.mediaTour), null);
+});
+
+test("extractMediaTour never throws on a garbage or empty input", () => {
+  assert.doesNotThrow(() => extractMediaTour({}));
+  assert.doesNotThrow(() => extractMediaTour("not an object"));
+  assert.doesNotThrow(() => extractMediaTour({ stops: "not an array" }));
+  assert.doesNotThrow(() => extractMediaTour({ stops: [null, undefined, 42] }));
+});
+
+test("extractMediaTour extracts sleepingArrangements with real content", () => {
+  const pdp = findPdpPresentation(fx.otherTours);
+  const out = extractMediaTour(pdp?.sleepingArrangements);
+  assert.equal(out.sectionTitle, "Where you'll sleep");
+  const b1 = out.stops.find((s) => s.name === "Bedroom 1");
+  assert.deepEqual(b1.captions, ["King bed"]);
+  assert.deepEqual(b1.amenities, ["King bed"]);
+});
+
+test("extractMediaTour extracts bathroomsTour with real content", () => {
+  const pdp = findPdpPresentation(fx.otherTours);
+  const out = extractMediaTour(pdp?.bathroomsTour);
+  assert.equal(out.sectionTitle, "What's the bathroom like");
+  const b1 = out.stops.find((s) => s.name === "Bathroom 1");
+  assert.deepEqual(b1.captions, ["Shower"]);
+  assert.deepEqual(b1.amenities, ["Hot water", "Shampoo"]);
+});
+
+test("extractMediaTour still returns a stop's captions when name is missing", () => {
+  const pdp = findPdpPresentation(fx.photoTourNameMissing);
+  const out = extractMediaTour(pdp?.mediaTour);
+  const stop = out.stops[0];
+  assert.ok(!("name" in stop), "missing name must omit name key");
+  assert.deepEqual(stop.captions, ["A nice room"]);
+  assert.deepEqual(stop.amenities, ["Some amenity"]);
 });

--- a/test/util.test.mjs
+++ b/test/util.test.mjs
@@ -1,0 +1,38 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { cleanObject, pickBySchema, flattenArraysInObject } from "../dist/util.js";
+
+// The helpers amenity/highlight recovery is built on had no coverage at all.
+
+test("pickBySchema copies only the keys the schema names", () => {
+  const out = pickBySchema({ a: 1, b: 2, c: { d: 3, e: 4 } }, { a: true, c: { d: true } });
+  assert.deepEqual(out, { a: 1, c: { d: 3 } });
+});
+
+test("pickBySchema maps over arrays", () => {
+  const out = pickBySchema([{ a: 1, b: 2 }, { a: 3, b: 4 }], { a: true });
+  assert.deepEqual(out, [{ a: 1 }, { a: 3 }]);
+});
+
+test("pickBySchema returns an empty object when the source is empty", () => {
+  // This is why a stubbed section reads as "no data" rather than "extraction broke".
+  assert.deepEqual(pickBySchema({}, { a: true }), {});
+});
+
+test("cleanObject removes nulls and __typename in place", () => {
+  const o = { a: 1, b: null, __typename: "X", c: { d: null, __typename: "Y", e: 2 } };
+  cleanObject(o);
+  assert.deepEqual(o, { a: 1, c: { e: 2 } });
+});
+
+test("flattenArraysInObject joins arrays of objects into a string", () => {
+  assert.equal(
+    flattenArraysInObject({ items: [{ title: "a" }, { title: "b" }] }).items,
+    "a, b"
+  );
+});
+
+test("flattenArraysInObject leaves primitives alone", () => {
+  assert.deepEqual(flattenArraysInObject({ a: 1, b: "x" }), { a: 1, b: "x" });
+});

--- a/util.ts
+++ b/util.ts
@@ -175,6 +175,76 @@ export function keyAmenityGroups(section: any): any {
   return { ...section, seeAllAmenitiesGroups: keyed };
 }
 
+/**
+ * `mediaTour`, `sleepingArrangements`, and `bathroomsTour` are three sibling keys
+ * under `pdpPresentation` that all share the same `MediaTour` shape - a photo tour
+ * with one stop per room/space:
+ *
+ *   MediaTour     = { name, stops: [MediaTourStop] }
+ *   MediaTourStop = { name, items: [{ image: { caption, imageId, uri, ... } }], description }
+ *
+ * The primary use case is a capacity check: a listing can claim N bedrooms while
+ * one "bedroom" stop is really a den, distinguishable only by which amenities its
+ * description lists relative to its peers (e.g. missing "Clothing storage" /
+ * "Hangers" / "Essentials" / "Room-darkening shades"). So the per-room amenity list
+ * is the primary payload here, not the images.
+ *
+ * Raw image data (uri, imageId, assetMetadata, tags) is deliberately never
+ * emitted - a photo tour holds dozens of images, and dumping their internals would
+ * undo this fork's whole reason for existing (staying far below stock token cost).
+ * Only stop name, deduped non-empty host captions, and the per-room amenity texts
+ * are surfaced.
+ *
+ * Partial-output tolerant throughout: any of `stops`, `items`, `caption`, or
+ * `description` may be missing, null, or malformed. A malformed individual stop or
+ * item is skipped rather than aborting the whole tour. Returns null - never throws,
+ * never emits an empty shell - when there is nothing worth reporting.
+ */
+export function extractMediaTour(tour: any): any | null {
+  if (!tour || typeof tour !== "object") return null;
+  const rawStops = Array.isArray(tour.stops) ? tour.stops : [];
+
+  const stops = rawStops
+    .map((stop: any) => {
+      if (!stop || typeof stop !== "object") return null;
+
+      const out: Record<string, any> = {};
+      if (typeof stop.name === "string" && stop.name.trim()) out.name = stop.name;
+
+      const items = Array.isArray(stop.items) ? stop.items : [];
+      const seen = new Set<string>();
+      const captions: string[] = [];
+      for (const item of items) {
+        const user = item?.image?.caption?.user;
+        const text = user?.localizedStringWithTranslationPreference ?? user?.localizedString;
+        if (typeof text !== "string") continue;
+        const trimmed = text.trim();
+        if (!trimmed || seen.has(trimmed)) continue;
+        seen.add(trimmed);
+        captions.push(trimmed);
+      }
+      if (captions.length) out.captions = captions;
+
+      const descriptions = stop.description?.descriptions;
+      if (Array.isArray(descriptions)) {
+        const amenities = descriptions
+          .map((d: any) => d?.text)
+          .filter((t: any) => typeof t === "string" && t.trim());
+        if (amenities.length) out.amenities = amenities;
+      }
+
+      return Object.keys(out).length ? out : null;
+    })
+    .filter((s: any): s is Record<string, any> => s !== null);
+
+  if (stops.length === 0) return null;
+
+  const out: Record<string, any> = { stops };
+  if (typeof tour.name === "string" && tour.name.trim()) out.sectionTitle = tour.name;
+  // Put sectionTitle first for readability - rebuild in the preferred key order.
+  return "sectionTitle" in out ? { sectionTitle: out.sectionTitle, stops: out.stops } : out;
+}
+
 export function extractHighlights(pdp: any): any | null {
   const highlights = pdp?.highlights;
   if (!Array.isArray(highlights) || highlights.length === 0) return null;


### PR DESCRIPTION
Closes #51.

Airbnb's PDP payload carries a photo tour (`mediaTour`, plus the
`sleepingArrangements` and `bathroomsTour` variants): a per-room breakdown with the
room name, its listed amenities, and image captions. None of it is exposed today,
which drops the most granular room-level facts the listing has — e.g. that a
5-bedroom listing's "Bedroom 5" lists no bed, or which bathrooms have a shower vs a
tub.

This PR exposes the tour in `airbnb_listing_details`:

- `extractMediaTour` in `util.ts` maps each stop to `{ name, amenities, imageCaptions }`,
  tolerating missing names, empty stops, `{ text }`-object description items,
  and whitespace/duplicate captions.
- The handler surfaces all three tour section variants when present, alongside the
  existing sections.

## Tests

- 11 fixture-driven cases in `test/pdp.test.mjs` (34 total pass): rich `mediaTour`
  extraction, positive `sleepingArrangements` and `bathroomsTour` fixtures, absence
  and empty-stops paths, nameless stops, caption normalization, and garbage input.
- Red-proof: with `extractMediaTour` reverted and tests kept, the suite fails on the
  missing export/behavior.

Stacked on #52: the diff includes its test-infrastructure commits until #52 merges;
the feature itself is the top commit.
