### PR TITLE
feat: expose cancellation policy, house rules, and occupancy

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,11 +244,18 @@ npm run watch
 ### Testing
 
 ```bash
-# Build, then run both suites
+# Build, then run the offline suite
 npm test
 ```
 
-`npm test` drives the built server over stdio and calls the tools for real:
+`npm test` runs the fixture-backed unit suite under `test/*.test.mjs` — no network access, safe for CI and for every install.
+
+```bash
+# Build, then drive the built server over stdio against the real site
+npm run test:live
+```
+
+`npm run test:live` calls the tools for real:
 
 - `test-extension.js` — MCP handshake, tool listing, a search, listing details, and the geocoding paths (Photon, Nominatim fallback)
 - `test-amenities.js` — amenity extraction across several live listings, checking that amenities Airbnb strikes through never appear as ones the listing offers

--- a/index.ts
+++ b/index.ts
@@ -11,7 +11,7 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 import fetch from "node-fetch";
 import * as cheerio from "cheerio";
-import { cleanObject, flattenArraysInObject, pickBySchema, diagnoseJsonPath, findPdpPresentation, extractAmenities, extractHighlights, keyAmenityGroups } from "./util.js";
+import { cleanObject, flattenArraysInObject, pickBySchema, diagnoseJsonPath, findPdpPresentation, extractAmenities, extractHighlights, keyAmenityGroups, extractOccupancy, findBookingPrefetchData, extractCancellationPolicies, extractHouseRules } from "./util.js";
 import robotsParser from "robots-parser";
 import { readFileSync } from 'fs';
 import { fileURLToPath } from 'url';
@@ -690,10 +690,17 @@ async function handleAirbnbListingDetails(params: any) {
     },
     "POLICIES_DEFAULT": {
       title: true,
+      cancellationPolicyTitle: true,
+      cancellationPolicyForDisplay: true,
+      houseRulesTitle: true,
+      houseRules: {
+        title: true
+      },
       houseRulesSections: {
         title: true,
-        items : {
-          title: true
+        items: {
+          title: true,
+          subtitle: true
         }
       }
     },
@@ -787,6 +794,36 @@ async function handleAirbnbListingDetails(params: any) {
             extracted.push({ id: sectionId, ...flattenArraysInObject(keyAmenityGroups(replacement.value)) });
           }
         }
+
+        // Occupancy lives on pdpPresentation, not on any allowlisted section.
+        const occupancy = extractOccupancy(pdp);
+        if (occupancy && !extracted.some((s: any) => s.id === "OCCUPANCY")) {
+          recovered.push("OCCUPANCY");
+          extracted.push({ id: "OCCUPANCY", ...occupancy });
+        }
+      }
+
+      // House rules: POLICIES_DEFAULT is still usually populated, but when it is a
+      // bare stub (or dropped), recover a labeled form via extractHouseRules.
+      const policiesSection = sections.find((s: any) => s.sectionId === "POLICIES_DEFAULT")?.section;
+      const houseRules = extractHouseRules(policiesSection);
+      if (houseRules) {
+        const existing = extracted.find((s: any) => s.id === "POLICIES_DEFAULT");
+        if (!existing) {
+          recovered.push("POLICIES_DEFAULT");
+          extracted.push({ id: "POLICIES_DEFAULT", ...flattenArraysInObject(houseRules) });
+        } else if (!existing.houseRulesSections && !existing.houseRules) {
+          recovered.push("POLICIES_DEFAULT");
+          Object.assign(existing, flattenArraysInObject(houseRules));
+        }
+      }
+
+      // Cancellation options live on metadata.bookingPrefetchData, not the
+      // section tree. Surface them as their own details entry when present.
+      const cancellation = extractCancellationPolicies(findBookingPrefetchData(clientData));
+      if (cancellation && !extracted.some((s: any) => s.id === "CANCELLATION_POLICY")) {
+        recovered.push("CANCELLATION_POLICY");
+        extracted.push({ id: "CANCELLATION_POLICY", ...flattenArraysInObject(cancellation) });
       }
 
       details = extracted;

--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
     "prepare": "npm run build",
     "version": "node sync-version.js && git add manifest.json",
     "pretest": "npm run build",
-    "test": "node test-extension.js && node test-amenities.js",
+    "test": "node --test test/*.test.mjs",
+    "pretest:live": "npm run build",
+    "test:live": "node test-extension.js && node test-amenities.js",
     "watch": "tsc --watch",
     "sync-version": "node sync-version.js"
   },

--- a/test-amenities.js
+++ b/test-amenities.js
@@ -13,7 +13,10 @@ function call(id) {
       stdio: ["pipe", "pipe", "pipe"],
     });
     let buf = "";
+    let toolCallSent = false;
     const timer = setTimeout(() => { proc.kill(); reject(new Error("timeout")); }, 60000);
+
+    const send = (o) => proc.stdin.write(JSON.stringify(o) + "\n");
 
     proc.stdout.on("data", (d) => {
       buf += d.toString();
@@ -21,23 +24,36 @@ function call(id) {
         if (!line.trim().startsWith("{")) continue;
         let msg;
         try { msg = JSON.parse(line); } catch { continue; }
+
+        // The id-1 reply, not a fixed sleep, is what says the server is ready.
+        if (msg.id === 1 && !toolCallSent) {
+          toolCallSent = true;
+          send({ jsonrpc: "2.0", method: "notifications/initialized" });
+          send({ jsonrpc: "2.0", id: 2, method: "tools/call", params: {
+            name: "airbnb_listing_details", arguments: { id, ignoreRobotsText: true } } });
+          continue;
+        }
+
         if (msg.id === 2) {
           clearTimeout(timer);
           proc.kill();
-          resolve(JSON.parse(msg.result.content[0].text));
+          if (msg.error) {
+            reject(new Error(`JSON-RPC error: ${JSON.stringify(msg.error)}`));
+            return;
+          }
+          const text = msg.result?.content?.[0]?.text;
+          if (!text) {
+            reject(new Error(`malformed tools/call response: ${JSON.stringify(msg)}`));
+            return;
+          }
+          resolve(JSON.parse(text));
         }
       }
     });
     proc.on("error", reject);
 
-    const send = (o) => proc.stdin.write(JSON.stringify(o) + "\n");
     send({ jsonrpc: "2.0", id: 1, method: "initialize", params: {
       protocolVersion: "2024-11-05", capabilities: {}, clientInfo: { name: "t", version: "1" } } });
-    setTimeout(() => {
-      send({ jsonrpc: "2.0", method: "notifications/initialized" });
-      send({ jsonrpc: "2.0", id: 2, method: "tools/call", params: {
-        name: "airbnb_listing_details", arguments: { id, ignoreRobotsText: true } } });
-    }, 700);
   });
 }
 

--- a/test-extension.js
+++ b/test-extension.js
@@ -24,7 +24,7 @@ class MCPTester {
 
   async startServer() {
     console.log('🚀 Starting MCP server...');
-    
+
     this.server = spawn('node', [SERVER_PATH, '--ignore-robots-txt'], {
       stdio: ['pipe', 'pipe', 'pipe'],
       env: { ...process.env, IGNORE_ROBOTS_TXT: 'true' }
@@ -34,13 +34,21 @@ class MCPTester {
       console.log('📋 Server log:', data.toString().trim());
     });
 
-    // Wait for server to start
-    await new Promise(resolve => setTimeout(resolve, 2000));
-    
     if (this.server.killed) {
       throw new Error('Server failed to start');
     }
-    
+
+    // Await the real initialize response instead of a fixed sleep.
+    const initResponse = await this.sendRequest('initialize', {
+      protocolVersion: '2024-11-05',
+      capabilities: {},
+      clientInfo: { name: 'test-extension', version: '1' },
+    });
+    if (initResponse.error) {
+      throw new Error(`initialize failed: ${initResponse.error.message}`);
+    }
+    this.server.stdin.write(JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' }) + '\n');
+
     console.log('✅ Server started successfully');
   }
 
@@ -260,6 +268,11 @@ class MCPTester {
           name: 'airbnb_search',
           arguments: { location: c.location, ignoreRobotsText: true },
         });
+        if (response.error) {
+          console.log(`   ❌ ${c.label}: JSON-RPC error: ${response.error.message || JSON.stringify(response.error)}`);
+          allOk = false;
+          continue;
+        }
         const url = this._extractSearchUrl(response);
         const bbox = parseBbox(url);
         if (!bbox) {

--- a/test/fixtures/pdp-presentation.json
+++ b/test/fixtures/pdp-presentation.json
@@ -1,0 +1,121 @@
+{
+  "_comment": "Shapes of niobeClientData[i][1].data.node.pdpPresentation. 'healthy' is trimmed from a real listing payload; the others are synthesized to exercise specific edge cases. Real entries carry a string operation-name key at index 0, not null.",
+
+  "healthy": {
+    "niobeClientData": [
+      ["StaysPdpSectionsQuery", { "data": { "presentation": {} } }],
+      ["StaysPdpReviewsQuery", {
+        "data": {
+          "node": {
+            "pdpPresentation": {
+              "amenities": {
+                "title": "What this place offers",
+                "seeAllAmenitiesGroups": [
+                  {
+                    "__typename": "AmenityItemsGroup",
+                    "title": "Heating and cooling",
+                    "amenities": [
+                      { "available": true, "title": "Central air conditioning", "subtitle": { "text": "" } },
+                      { "available": true, "title": "Ceiling fan", "subtitle": { "text": "" } }
+                    ]
+                  },
+                  {
+                    "__typename": "AmenityItemsGroup",
+                    "title": "Not included",
+                    "amenities": [
+                      { "available": false, "title": "Dryer", "subtitle": { "text": "" } },
+                      { "available": false, "title": "Hot water", "subtitle": { "text": "" } }
+                    ]
+                  }
+                ]
+              },
+              "highlights": [
+                { "title": "Dive right in", "subtitle": "This is one of the few places in the area with a pool." },
+                { "title": "Peace and quiet" }
+              ]
+            }
+          }
+        }
+      }]
+    ]
+  },
+
+  "amenitiesOnly": {
+    "_comment": "Highlights have moved or vanished, amenities are fine. Partial extraction must still return the amenities.",
+    "niobeClientData": [
+      ["StaysPdpSectionsQuery", {
+        "data": {
+          "node": {
+            "pdpPresentation": {
+              "amenities": {
+                "title": "What this place offers",
+                "seeAllAmenitiesGroups": [
+                  {
+                    "title": "Heating and cooling",
+                    "amenities": [{ "available": true, "title": "AC - split type ductless system" }]
+                  }
+                ]
+              },
+              "highlights": null
+            }
+          }
+        }
+      }]
+    ]
+  },
+
+  "partiallyMalformedGroups": {
+    "_comment": "One amenity group is garbage. The healthy groups around it must survive.",
+    "niobeClientData": [
+      ["StaysPdpSectionsQuery", {
+        "data": {
+          "node": {
+            "pdpPresentation": {
+              "amenities": {
+                "seeAllAmenitiesGroups": [
+                  { "title": "Bathroom", "amenities": [{ "available": true, "title": "Hair dryer" }] },
+                  { "title": "Broken group", "amenities": "this should be an array" },
+                  { "title": "Kitchen", "amenities": [{ "available": true, "title": "Oven" }] }
+                ]
+              }
+            }
+          }
+        }
+      }]
+    ]
+  },
+
+  "noPdpBranch": {
+    "_comment": "Airbnb moved the branch again. Extraction must return null, not throw.",
+    "niobeClientData": [["StaysPdpSectionsQuery", { "data": { "presentation": {} } }]]
+  },
+
+  "subtitleShapes": {
+    "_comment": "Airbnb has shipped amenity and highlight subtitles as both a plain string and a { text } object. Both shapes must produce the same label.",
+    "niobeClientData": [
+      ["StaysPdpSectionsQuery", {
+        "data": {
+          "node": {
+            "pdpPresentation": {
+              "amenities": {
+                "seeAllAmenitiesGroups": [
+                  {
+                    "title": "Bathroom",
+                    "amenities": [
+                      { "available": true, "title": "Shampoo", "subtitle": "Body wash" },
+                      { "available": true, "title": "Hair dryer", "subtitle": { "text": "1200W" } }
+                    ]
+                  }
+                ]
+              },
+              "highlights": [
+                { "title": "Great location", "subtitle": "Walk to the beach" },
+                { "title": "Self check-in", "subtitle": { "text": "Check yourself in with the keypad." } }
+              ]
+            }
+          }
+        }
+      }]
+    ]
+  }
+}

--- a/test/fixtures/pdp-presentation.json
+++ b/test/fixtures/pdp-presentation.json
@@ -117,5 +117,166 @@
         }
       }]
     ]
+  },
+
+  "withOccupancy": {
+    "_comment": "personCapacity is a top-level number on pdpPresentation. Extraction must surface it; absence must return null.",
+    "niobeClientData": [
+      ["StaysPdpSectionsQuery", {
+        "data": {
+          "node": {
+            "pdpPresentation": {
+              "personCapacity": 10,
+              "highlights": [{ "title": "Great location" }]
+            }
+          }
+        }
+      }]
+    ]
+  },
+
+  "policiesSection": {
+    "_comment": "Realistic POLICIES_DEFAULT.section shape: grouped house rules with a quiet-hours subtitle. Cancellation is null here — it lives on bookingPrefetchData.",
+    "title": "Things to know",
+    "cancellationPolicyTitle": "Cancellation policy",
+    "cancellationPolicyForDisplay": null,
+    "houseRulesTitle": "House rules",
+    "houseRules": [
+      { "title": "Check-in after 3:00 PM" },
+      { "title": "Checkout before 11:00 AM" },
+      { "title": "10 guests maximum" }
+    ],
+    "houseRulesSections": [
+      {
+        "title": "Checking in and out",
+        "items": [
+          { "title": "Check-in after 3:00 PM" },
+          { "title": "Checkout before 11:00 AM" },
+          { "title": "Self check-in with smart lock" }
+        ]
+      },
+      {
+        "title": "During your stay",
+        "items": [
+          { "title": "10 guests maximum" },
+          { "title": "No pets" },
+          { "title": "Quiet hours", "subtitle": "11:00 PM - 7:00 AM" },
+          { "title": "No parties or events" },
+          { "title": "No smoking" }
+        ]
+      }
+    ]
+  },
+
+  "policiesPreviewOnly": {
+    "_comment": "Only the short houseRules preview is present — sections tree is gone.",
+    "houseRulesTitle": "House rules",
+    "houseRules": [
+      { "title": "Check-in after 4:00 PM" },
+      { "title": "7 guests maximum" }
+    ]
+  },
+
+  "bookingPrefetch": {
+    "_comment": "sections.metadata.bookingPrefetchData shape for dual-rate cancellation (snake_case, as shipped).",
+    "cancellationPolicies": [
+      {
+        "__typename": "LegacyPdpCancellationSection",
+        "cancellation_policy_price_type": "TIERED_PRICING_STANDARD",
+        "book_it_module_tooltip": "Free cancellation for 24 hours. After that, the reservation is non-refundable.",
+        "cancellation_policy_id": 51,
+        "localized_cancellation_policy_name": "Non-refundable"
+      },
+      {
+        "__typename": "LegacyPdpCancellationSection",
+        "cancellation_policy_price_type": "TIERED_PRICING_FLEXIBLE",
+        "book_it_module_tooltip": "Free cancellation before September 26. Cancel before check-in on October 1 for a partial refund.",
+        "cancellation_policy_id": 4,
+        "localized_cancellation_policy_name": "Refundable",
+        "price": "$138.67"
+      }
+    ]
+  },
+
+  "bookingPrefetchCamel": {
+    "_comment": "Same dual-rate shape with camelCase keys, in case Airbnb renames the legacy fields.",
+    "cancellationPolicies": [
+      {
+        "localizedCancellationPolicyName": "Flexible",
+        "bookItModuleTooltip": "Full refund up to 24 hours before check-in.",
+        "cancellationPolicyPriceType": "TIERED_PRICING_FLEXIBLE"
+      }
+    ]
+  },
+
+  "clientDataWithPrefetch": {
+    "_comment": "Minimal clientData path used by findBookingPrefetchData.",
+    "niobeClientData": [
+      [null, {
+        "data": {
+          "presentation": {
+            "stayProductDetailPage": {
+              "sections": {
+                "metadata": {
+                  "bookingPrefetchData": {
+                    "cancellationPolicies": [
+                      {
+                        "localized_cancellation_policy_name": "Moderate",
+                        "book_it_module_tooltip": "Full refund up to 5 days before check-in."
+                      }
+                    ]
+                  }
+                },
+                "sections": []
+              }
+            }
+          }
+        }
+      }]
+    ]
+  },
+  "clientDataPrefetchAtNonZeroIndex": {
+    "_comment": "Prefetch branch at niobeClientData[1]; [0] is a decoy without bookingPrefetchData (guards against hardcoding [0][1]).",
+    "niobeClientData": [
+      [
+        null,
+        {
+          "data": {
+            "presentation": {
+              "stayProductDetailPage": {
+                "sections": {
+                  "metadata": {},
+                  "sections": []
+                }
+              }
+            }
+          }
+        }
+      ],
+      [
+        null,
+        {
+          "data": {
+            "presentation": {
+              "stayProductDetailPage": {
+                "sections": {
+                  "metadata": {
+                    "bookingPrefetchData": {
+                      "cancellationPolicies": [
+                        {
+                          "localized_cancellation_policy_name": "Flexible",
+                          "book_it_module_tooltip": "Full refund 1 day prior to arrival."
+                        }
+                      ]
+                    }
+                  },
+                  "sections": []
+                }
+              }
+            }
+          }
+        }
+      ]
+    ]
   }
 }

--- a/test/pdp.test.mjs
+++ b/test/pdp.test.mjs
@@ -1,0 +1,213 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import {
+  findPdpPresentation,
+  extractAmenities,
+  extractHighlights,
+  keyAmenityGroups,
+} from "../dist/util.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const fx = JSON.parse(
+  readFileSync(join(__dirname, "fixtures", "pdp-presentation.json"), "utf8")
+);
+
+test("findPdpPresentation locates the branch without hardcoding an index", () => {
+  assert.ok(findPdpPresentation(fx.healthy));
+  assert.equal(findPdpPresentation(fx.noPdpBranch), null);
+  assert.equal(findPdpPresentation({}), null);
+  assert.equal(findPdpPresentation(null), null);
+});
+
+test("extractAmenities passes through the section title", () => {
+  const out = extractAmenities(findPdpPresentation(fx.healthy));
+  assert.equal(out.title, "What this place offers");
+});
+
+test("an all-unavailable group is left unmarked; its title carries the meaning", () => {
+  const out = extractAmenities(findPdpPresentation(fx.healthy));
+  const heat = out.seeAllAmenitiesGroups.find((g) => g.title === "Heating and cooling");
+  const not = out.seeAllAmenitiesGroups.find((g) => g.title === "Not included");
+  assert.deepEqual(heat.amenities, ["Central air conditioning", "Ceiling fan"]);
+  // available:false is how Airbnb renders a struck-through amenity. The mechanism
+  // is availability homogeneity, not the group's title: a group where every item
+  // shares the same availability is left unmarked because the group's own name -
+  // whatever it is - already tells the story. Only a group mixing available and
+  // unavailable items needs its unavailable items called out individually. This
+  // fixture's homogeneous group happens to be titled "Not included", but that
+  // title is not what triggers the behavior - see the next test.
+  assert.deepEqual(not.amenities, ["Dryer", "Hot water"]);
+});
+
+test("a homogeneously-unavailable group is left unmarked under any title, not just 'Not included'", () => {
+  const pdp = {
+    amenities: {
+      seeAllAmenitiesGroups: [
+        {
+          title: "Kitchen extras",
+          amenities: [
+            { title: "Wine glasses", available: false },
+            { title: "Coffee maker", available: false },
+          ],
+        },
+      ],
+    },
+  };
+  const out = extractAmenities(pdp);
+  assert.deepEqual(out.seeAllAmenitiesGroups[0].amenities, ["Wine glasses", "Coffee maker"]);
+});
+
+test("a group mixing available and unavailable items marks the unavailable ones", () => {
+  const pdp = {
+    amenities: {
+      seeAllAmenitiesGroups: [
+        {
+          title: "Laundry",
+          amenities: [
+            { title: "Washer", available: true },
+            { title: "Dryer", available: false },
+          ],
+        },
+      ],
+    },
+  };
+  const out = extractAmenities(pdp);
+  assert.deepEqual(out.seeAllAmenitiesGroups[0].amenities, [
+    "Washer",
+    "Dryer — unavailable",
+  ]);
+});
+
+test("extractHighlights joins a subtitle onto its title when present", () => {
+  const out = extractHighlights(findPdpPresentation(fx.healthy));
+  assert.deepEqual(out.highlights, [
+    "Dive right in: This is one of the few places in the area with a pool.",
+    "Peace and quiet",
+  ]);
+});
+
+// --- partial extraction: one field failing must not cost the others ---
+
+test("amenities still extract when highlights are gone", () => {
+  const pdp = findPdpPresentation(fx.amenitiesOnly);
+  const amenities = extractAmenities(pdp);
+  assert.ok(amenities, "amenities must survive a missing highlights field");
+  assert.deepEqual(amenities.seeAllAmenitiesGroups[0].amenities, [
+    "AC - split type ductless system",
+  ]);
+  assert.equal(extractHighlights(pdp), null, "missing highlights report as null, not as an error");
+});
+
+test("a malformed amenity group does not destroy the healthy groups around it", () => {
+  const out = extractAmenities(findPdpPresentation(fx.partiallyMalformedGroups));
+  const titles = out.seeAllAmenitiesGroups.map((g) => g.title);
+  assert.ok(titles.includes("Bathroom"), "groups before the bad one must survive");
+  assert.ok(titles.includes("Kitchen"), "groups after the bad one must survive");
+  const bathroom = out.seeAllAmenitiesGroups.find((g) => g.title === "Bathroom");
+  assert.deepEqual(bathroom.amenities, ["Hair dryer"]);
+});
+
+test("extraction returns null rather than throwing when the branch moves", () => {
+  assert.equal(extractAmenities(null), null);
+  assert.equal(extractAmenities({}), null);
+  assert.equal(extractHighlights(null), null);
+  assert.equal(extractHighlights({}), null);
+});
+
+test("extractAmenities returns null when every group is empty", () => {
+  const pdp = {
+    amenities: {
+      seeAllAmenitiesGroups: [
+        { title: "Bathroom", amenities: [] },
+        { title: "Kitchen", amenities: [] },
+      ],
+    },
+  };
+  assert.equal(extractAmenities(pdp), null);
+});
+
+// --- subtitle shape: Airbnb has shipped this as both a plain string and a
+// { text } object, on both amenities and highlights. Both must label the same. ---
+
+test("extractAmenities labels a string subtitle and a { text } subtitle identically", () => {
+  const pdp = findPdpPresentation(fx.subtitleShapes);
+  const out = extractAmenities(pdp);
+  assert.deepEqual(out.seeAllAmenitiesGroups[0].amenities, [
+    "Shampoo (Body wash)",
+    "Hair dryer (1200W)",
+  ]);
+});
+
+test("extractHighlights labels a string subtitle and a { text } subtitle identically", () => {
+  const pdp = findPdpPresentation(fx.subtitleShapes);
+  const out = extractHighlights(pdp);
+  assert.deepEqual(out.highlights, [
+    "Great location: Walk to the beach",
+    "Self check-in: Check yourself in with the keypad.",
+  ]);
+});
+
+// --- keyAmenityGroups: no coverage at all before this branch ---
+
+test("keyAmenityGroups keys groups by title", () => {
+  const section = {
+    seeAllAmenitiesGroups: [
+      { title: "Bathroom", amenities: [{ title: "Hair dryer" }] },
+      { title: "Kitchen", amenities: [{ title: "Oven" }] },
+    ],
+  };
+  const out = keyAmenityGroups(section);
+  assert.deepEqual(out.seeAllAmenitiesGroups, {
+    Bathroom: [{ title: "Hair dryer" }],
+    Kitchen: [{ title: "Oven" }],
+  });
+});
+
+test("keyAmenityGroups falls back to 'Other' for an untitled group", () => {
+  const section = {
+    seeAllAmenitiesGroups: [{ amenities: [{ title: "Mystery item" }] }],
+  };
+  const out = keyAmenityGroups(section);
+  assert.deepEqual(out.seeAllAmenitiesGroups, { Other: [{ title: "Mystery item" }] });
+});
+
+test("keyAmenityGroups merges duplicate titles by concatenation, not overwrite", () => {
+  const section = {
+    seeAllAmenitiesGroups: [
+      { title: "Bathroom", amenities: [{ title: "Hair dryer" }] },
+      { title: "Bathroom", amenities: [{ title: "Shampoo" }] },
+    ],
+  };
+  const out = keyAmenityGroups(section);
+  assert.deepEqual(out.seeAllAmenitiesGroups.Bathroom, [
+    { title: "Hair dryer" },
+    { title: "Shampoo" },
+  ]);
+});
+
+test("keyAmenityGroups drops groups that have no amenities", () => {
+  const section = {
+    seeAllAmenitiesGroups: [
+      { title: "Bathroom", amenities: [] },
+      { title: "Kitchen", amenities: [{ title: "Oven" }] },
+    ],
+  };
+  const out = keyAmenityGroups(section);
+  assert.deepEqual(out.seeAllAmenitiesGroups, { Kitchen: [{ title: "Oven" }] });
+  assert.ok(!("Bathroom" in out.seeAllAmenitiesGroups));
+});
+
+test("keyAmenityGroups passes through non-matching objects, arrays, and null unchanged", () => {
+  assert.equal(keyAmenityGroups(null), null);
+  assert.equal(keyAmenityGroups(42), 42);
+
+  const arr = [1, 2, 3];
+  assert.equal(keyAmenityGroups(arr), arr);
+
+  const noGroups = { foo: "bar" };
+  assert.deepEqual(keyAmenityGroups(noGroups), noGroups);
+});

--- a/test/pdp.test.mjs
+++ b/test/pdp.test.mjs
@@ -9,6 +9,10 @@ import {
   extractAmenities,
   extractHighlights,
   keyAmenityGroups,
+  extractOccupancy,
+  findBookingPrefetchData,
+  extractCancellationPolicies,
+  extractHouseRules,
 } from "../dist/util.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -210,4 +214,121 @@ test("keyAmenityGroups passes through non-matching objects, arrays, and null unc
 
   const noGroups = { foo: "bar" };
   assert.deepEqual(keyAmenityGroups(noGroups), noGroups);
+});
+
+// --- occupancy ---
+
+test("extractOccupancy surfaces personCapacity from pdpPresentation", () => {
+  const out = extractOccupancy(findPdpPresentation(fx.withOccupancy));
+  assert.deepEqual(out, { personCapacity: 10 });
+});
+
+test("extractOccupancy returns null when personCapacity is absent or non-numeric", () => {
+  assert.equal(extractOccupancy(null), null);
+  assert.equal(extractOccupancy({}), null);
+  assert.equal(extractOccupancy(findPdpPresentation(fx.healthy)), null);
+  assert.equal(extractOccupancy({ personCapacity: "10" }), null);
+});
+
+// --- house rules ---
+
+test("extractHouseRules preserves quiet-hours subtitles on grouped rules", () => {
+  const out = extractHouseRules(fx.policiesSection);
+  assert.equal(out.title, "Things to know");
+  assert.equal(out.houseRulesTitle, "House rules");
+  const during = out.houseRulesSections.find((s) => s.title === "During your stay");
+  assert.ok(during.items.includes("Quiet hours: 11:00 PM - 7:00 AM"));
+  assert.ok(during.items.includes("10 guests maximum"));
+  assert.ok(during.items.includes("No pets"));
+});
+
+test("extractHouseRules falls back to the short houseRules preview", () => {
+  const out = extractHouseRules(fx.policiesPreviewOnly);
+  assert.deepEqual(out.houseRules, [
+    "Check-in after 4:00 PM",
+    "7 guests maximum",
+  ]);
+  assert.equal(out.title, "House rules");
+});
+
+test("extractHouseRules labels a string subtitle and a { text } subtitle identically", () => {
+  const section = {
+    houseRulesSections: [
+      {
+        title: "During your stay",
+        items: [
+          { title: "Quiet hours", subtitle: "10:00 PM - 7:00 AM" },
+          { title: "Quiet hours", subtitle: { text: "10:00 PM - 7:00 AM" } },
+        ],
+      },
+    ],
+  };
+  const out = extractHouseRules(section);
+  assert.deepEqual(out.houseRulesSections[0].items, [
+    "Quiet hours: 10:00 PM - 7:00 AM",
+    "Quiet hours: 10:00 PM - 7:00 AM",
+  ]);
+});
+
+test("extractHouseRules returns null rather than throwing when rules are gone", () => {
+  assert.equal(extractHouseRules(null), null);
+  assert.equal(extractHouseRules({}), null);
+  assert.equal(extractHouseRules({ houseRulesSections: [] }), null);
+  assert.equal(extractHouseRules({ houseRules: [] }), null);
+});
+
+// --- cancellation policies ---
+
+test("extractCancellationPolicies surfaces dual-rate options with upgrade price", () => {
+  const out = extractCancellationPolicies(fx.bookingPrefetch);
+  assert.deepEqual(out.cancellationPolicies, [
+    {
+      name: "Non-refundable",
+      description:
+        "Free cancellation for 24 hours. After that, the reservation is non-refundable.",
+      priceType: "TIERED_PRICING_STANDARD",
+    },
+    {
+      name: "Refundable",
+      description:
+        "Free cancellation before September 26. Cancel before check-in on October 1 for a partial refund.",
+      priceType: "TIERED_PRICING_FLEXIBLE",
+      price: "$138.67",
+    },
+  ]);
+});
+
+test("extractCancellationPolicies accepts camelCase field names", () => {
+  const out = extractCancellationPolicies(fx.bookingPrefetchCamel);
+  assert.deepEqual(out.cancellationPolicies, [
+    {
+      name: "Flexible",
+      description: "Full refund up to 24 hours before check-in.",
+      priceType: "TIERED_PRICING_FLEXIBLE",
+    },
+  ]);
+});
+
+test("findBookingPrefetchData walks the clientData path without hardcoding beyond the known tree", () => {
+  const prefetch = findBookingPrefetchData(fx.clientDataWithPrefetch);
+  assert.ok(prefetch);
+  const out = extractCancellationPolicies(prefetch);
+  assert.equal(out.cancellationPolicies[0].name, "Moderate");
+});
+
+test("findBookingPrefetchData finds prefetch when it is not at niobeClientData[0]", () => {
+  const prefetch = findBookingPrefetchData(fx.clientDataPrefetchAtNonZeroIndex);
+  assert.ok(prefetch, "expected bookingPrefetchData on a non-zero niobeClientData entry");
+  const out = extractCancellationPolicies(prefetch);
+  assert.equal(out.cancellationPolicies[0].name, "Flexible");
+  assert.equal(out.cancellationPolicies[0].description, "Full refund 1 day prior to arrival.");
+});
+
+test("extractCancellationPolicies returns null when the array is absent or empty", () => {
+  assert.equal(extractCancellationPolicies(null), null);
+  assert.equal(extractCancellationPolicies({}), null);
+  assert.equal(extractCancellationPolicies({ cancellationPolicies: [] }), null);
+  assert.equal(extractCancellationPolicies({ cancellationPolicies: [{ noName: true }] }), null);
+  assert.equal(findBookingPrefetchData({}), null);
+  assert.equal(findBookingPrefetchData(null), null);
 });

--- a/test/util.test.mjs
+++ b/test/util.test.mjs
@@ -1,0 +1,38 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { cleanObject, pickBySchema, flattenArraysInObject } from "../dist/util.js";
+
+// The helpers amenity/highlight recovery is built on had no coverage at all.
+
+test("pickBySchema copies only the keys the schema names", () => {
+  const out = pickBySchema({ a: 1, b: 2, c: { d: 3, e: 4 } }, { a: true, c: { d: true } });
+  assert.deepEqual(out, { a: 1, c: { d: 3 } });
+});
+
+test("pickBySchema maps over arrays", () => {
+  const out = pickBySchema([{ a: 1, b: 2 }, { a: 3, b: 4 }], { a: true });
+  assert.deepEqual(out, [{ a: 1 }, { a: 3 }]);
+});
+
+test("pickBySchema returns an empty object when the source is empty", () => {
+  // This is why a stubbed section reads as "no data" rather than "extraction broke".
+  assert.deepEqual(pickBySchema({}, { a: true }), {});
+});
+
+test("cleanObject removes nulls and __typename in place", () => {
+  const o = { a: 1, b: null, __typename: "X", c: { d: null, __typename: "Y", e: 2 } };
+  cleanObject(o);
+  assert.deepEqual(o, { a: 1, c: { e: 2 } });
+});
+
+test("flattenArraysInObject joins arrays of objects into a string", () => {
+  assert.equal(
+    flattenArraysInObject({ items: [{ title: "a" }, { title: "b" }] }).items,
+    "a, b"
+  );
+});
+
+test("flattenArraysInObject leaves primitives alone", () => {
+  assert.deepEqual(flattenArraysInObject({ a: 1, b: "x" }), { a: 1, b: "x" });
+});

--- a/util.ts
+++ b/util.ts
@@ -192,3 +192,122 @@ export function extractHighlights(pdp: any): any | null {
 
   return mapped.length ? { highlights: mapped } : null;
 }
+
+/** Finite personCapacity on pdpPresentation; null when missing/non-numeric. */
+export function extractOccupancy(pdp: any): any | null {
+  const capacity = pdp?.personCapacity;
+  if (typeof capacity !== "number" || !Number.isFinite(capacity)) return null;
+  return { personCapacity: capacity };
+}
+
+/**
+ * bookingPrefetchData lives on section-tree metadata, not pdpPresentation.
+ * Walks niobeClientData like findPdpPresentation — index 0 is not guaranteed.
+ */
+export function findBookingPrefetchData(clientData: any): any | null {
+  const entries = clientData?.niobeClientData;
+  if (!Array.isArray(entries)) return null;
+  for (const entry of entries) {
+    const prefetch =
+      entry?.[1]?.data?.presentation?.stayProductDetailPage?.sections?.metadata
+        ?.bookingPrefetchData;
+    if (prefetch && typeof prefetch === "object") return prefetch;
+  }
+  return null;
+}
+
+export function extractCancellationPolicies(prefetch: any): any | null {
+  const policies = prefetch?.cancellationPolicies;
+  if (!Array.isArray(policies) || policies.length === 0) return null;
+
+  const mapped = policies
+    .map((p: any) => {
+      // Airbnb has shipped both snake_case (legacy) and camelCase keys.
+      const name =
+        p?.localized_cancellation_policy_name ??
+        p?.localizedCancellationPolicyName ??
+        null;
+      if (!name) return null;
+
+      const description =
+        typeof p?.book_it_module_tooltip === "string"
+          ? p.book_it_module_tooltip
+          : typeof p?.bookItModuleTooltip === "string"
+            ? p.bookItModuleTooltip
+            : null;
+
+      const priceType =
+        p?.cancellation_policy_price_type ??
+        p?.cancellationPolicyPriceType ??
+        null;
+
+      // Price field names vary and are often absent from the initial SSR payload.
+      const price =
+        p?.price ??
+        p?.displayPrice?.amount ??
+        p?.structuredDisplayPrice?.primaryLine?.price ??
+        p?.optionalityPriceDetail?.price ??
+        null;
+
+      return {
+        name,
+        ...(description ? { description } : {}),
+        ...(priceType ? { priceType } : {}),
+        ...(price != null && price !== "" ? { price } : {}),
+      };
+    })
+    .filter(Boolean);
+
+  return mapped.length ? { cancellationPolicies: mapped } : null;
+}
+
+/** POLICIES_DEFAULT house rules: full sections first, then short preview list. */
+export function extractHouseRules(policiesSection: any): any | null {
+  if (!policiesSection || typeof policiesSection !== "object") return null;
+
+  const label = (item: any) => {
+    const title = item?.title;
+    if (!title) return null;
+    const sub =
+      typeof item?.subtitle === "string"
+        ? item.subtitle
+        : item?.subtitle?.text;
+    return sub ? `${title}: ${sub}` : title;
+  };
+
+  const sections = policiesSection.houseRulesSections;
+  if (Array.isArray(sections) && sections.length > 0) {
+    const mapped = sections
+      .map((sec: any) => {
+        const items = Array.isArray(sec?.items) ? sec.items : [];
+        const labeled = items.map(label).filter(Boolean);
+        return labeled.length ? { title: sec?.title, items: labeled } : null;
+      })
+      .filter(Boolean);
+
+    if (mapped.length) {
+      return {
+        ...(policiesSection.title ? { title: policiesSection.title } : {}),
+        ...(policiesSection.houseRulesTitle
+          ? { houseRulesTitle: policiesSection.houseRulesTitle }
+          : {}),
+        houseRulesSections: mapped,
+      };
+    }
+  }
+
+  const preview = policiesSection.houseRules;
+  if (Array.isArray(preview) && preview.length > 0) {
+    const items = preview.map(label).filter(Boolean);
+    if (items.length) {
+      return {
+        ...(policiesSection.houseRulesTitle
+          ? { title: policiesSection.houseRulesTitle }
+          : {}),
+        houseRules: items,
+      };
+    }
+  }
+
+  return null;
+}


### PR DESCRIPTION
Fixes #50.

`airbnb_listing_details` recovered amenities and highlights from
`pdpPresentation`, but three other decision inputs stayed buried in the
payload:

- **Cancellation policy options** (non-refundable vs refundable upgrade),
  including a description of the refund window and an upgrade price when
  Airbnb attaches one.
- **House rules** with item subtitles (e.g. quiet-hour windows), not just
  bare titles.
- **Occupancy** (`personCapacity`) so a caller can compare it against the
  "N guests maximum" house-rule line when the two disagree.

## Where the data actually lives

Live payloads (listing `1425762021690163826` with dates selected) put these
in slightly different places than the section tree:

| Field | Source |
|---|---|
| `personCapacity` | `niobeClientData[*][1].data.node.pdpPresentation` |
| house rules (+ subtitles) | `POLICIES_DEFAULT.section.houseRulesSections` |
| cancellation options | `sections.metadata.bookingPrefetchData.cancellationPolicies` |

House rules were already partially returned via `allowSectionSchema`, but
item **subtitles** were dropped. Cancellation and occupancy were absent
from the tool output entirely.

## Approach

Pure extractors in `util.ts`, matching `extractAmenities` /
`extractHighlights`:

- `extractOccupancy(pdp)` → `{ personCapacity }`
- `extractHouseRules(policiesSection)` → grouped rules with labeled
  subtitles; falls back to the short `houseRules` preview
- `extractCancellationPolicies(prefetch)` → dual-rate options; tolerates
  both snake_case and camelCase keys; optional `price` when present
- `findBookingPrefetchData(clientData)` → locates the prefetch branch

Wired in `handleAirbnbListingDetails`:

- expand `POLICIES_DEFAULT` schema to keep house-rule subtitles and the
  cancellation title/display fields when they are on the section
- push `OCCUPANCY` and `CANCELLATION_POLICY` detail entries when recovered
- recover `POLICIES_DEFAULT` from `extractHouseRules` if the section is
  stubbed or dropped

No new tool parameters; output-only surface.

`findBookingPrefetchData` iterates `niobeClientData` rather than assuming the
prefetch branch's position; a fixture places it at a non-zero index to prove it.

## Tests

Offline fixture suite (`npm test`):

- occupancy present / absent / non-numeric
- house rules subtitles (string and `{ text }`), preview fallback, null
- cancellation dual-rate + upgrade price, camelCase, null / empty
- `findBookingPrefetchData` path walk, including prefetch at a non-zero index

Revert-proof: stub the four extractors to `return null` → new tests fail
with the issue symptom (fields absent) → restore → full suite green
(34 pass / 0 fail).

## Verification

```
$ npm test
ℹ tests 34
ℹ pass 34
ℹ fail 0
```

Live spot-check (not a gate): listing `1425762021690163826` with
`check_in=2026-10-01&check_out=2026-10-05` yields
`personCapacity: 10`, dual-rate cancellation names + tooltips, and
`Quiet hours: 11:00 PM - 7:00 AM` under house rules.

Note: the refundable-upgrade dollar amount is often missing from the
initial SSR payload even when both rate names are present; the extractor
surfaces `price` when Airbnb attaches it (fixture covers `$138.67`).

Stacked on #52: the diff includes its test-infrastructure commits until #52 merges;
the feature itself is the top commit.
