### PR TITLE
fix: surface Superhost status on search badges and listing details

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,11 +244,18 @@ npm run watch
 ### Testing
 
 ```bash
-# Build, then run both suites
+# Build, then run the offline suite
 npm test
 ```
 
-`npm test` drives the built server over stdio and calls the tools for real:
+`npm test` runs the fixture-backed unit suite under `test/*.test.mjs` — no network access, safe for CI and for every install.
+
+```bash
+# Build, then drive the built server over stdio against the real site
+npm run test:live
+```
+
+`npm run test:live` calls the tools for real:
 
 - `test-extension.js` — MCP handshake, tool listing, a search, listing details, and the geocoding paths (Photon, Nominatim fallback)
 - `test-amenities.js` — amenity extraction across several live listings, checking that amenities Airbnb strikes through never appear as ones the listing offers

--- a/index.ts
+++ b/index.ts
@@ -11,7 +11,7 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 import fetch from "node-fetch";
 import * as cheerio from "cheerio";
-import { cleanObject, flattenArraysInObject, pickBySchema, diagnoseJsonPath, findPdpPresentation, extractAmenities, extractHighlights, keyAmenityGroups } from "./util.js";
+import { cleanObject, flattenArraysInObject, pickBySchema, diagnoseJsonPath, findPdpPresentation, extractAmenities, extractHighlights, keyAmenityGroups, extractHostInfo, extractBadgeType, searchBadgeSchema } from "./util.js";
 import robotsParser from "robots-parser";
 import { readFileSync } from 'fs';
 import { fileURLToPath } from 'url';
@@ -496,9 +496,7 @@ async function handleAirbnbSearch(params: any) {
       description: true,
       location: true,
     },
-    badges: {
-      text: true,
-    },
+    badges: searchBadgeSchema,
     structuredContent: {
       mapCategoryInfo: {
         body: true
@@ -564,7 +562,15 @@ async function handleAirbnbSearch(params: any) {
       
       staysSearchResults = {
         searchResults: results.searchResults
-          .map((result: any) => flattenArraysInObject(pickBySchema(result, allowSearchResultSchema)))
+          .map((result: any) => {
+            // badgeType must be read before flatten collapses badges to a string.
+            // Same attach-after-flatten pattern as priceBreakdown: structured data
+            // rides alongside the card, never inside the flattened badges string.
+            const badgeType = extractBadgeType(result);
+            const flat = flattenArraysInObject(pickBySchema(result, allowSearchResultSchema));
+            if (badgeType) flat.badgeType = badgeType;
+            return flat;
+          })
           .map((result: any) => {
             const id = atob(result.demandStayListing.id).split(":")[1];
             return {id, url: `${BASE_URL}/rooms/${id}`, ...result }
@@ -786,6 +792,13 @@ async function handleAirbnbListingDetails(params: any) {
             recovered.push(sectionId);
             extracted.push({ id: sectionId, ...flattenArraysInObject(keyAmenityGroups(replacement.value)) });
           }
+        }
+
+        // HOST is additive (MEET_YOUR_HOST is a stub). Superhost lives on passportData.
+        const host = extractHostInfo(pdp);
+        if (host && !extracted.some((s: any) => s.id === "HOST")) {
+          recovered.push("HOST");
+          extracted.push({ id: "HOST", ...host });
         }
       }
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
     "prepare": "npm run build",
     "version": "node sync-version.js && git add manifest.json",
     "pretest": "npm run build",
-    "test": "node test-extension.js && node test-amenities.js",
+    "test": "node --test test/*.test.mjs",
+    "pretest:live": "npm run build",
+    "test:live": "node test-extension.js && node test-amenities.js",
     "watch": "tsc --watch",
     "sync-version": "node sync-version.js"
   },

--- a/test-amenities.js
+++ b/test-amenities.js
@@ -13,7 +13,10 @@ function call(id) {
       stdio: ["pipe", "pipe", "pipe"],
     });
     let buf = "";
+    let toolCallSent = false;
     const timer = setTimeout(() => { proc.kill(); reject(new Error("timeout")); }, 60000);
+
+    const send = (o) => proc.stdin.write(JSON.stringify(o) + "\n");
 
     proc.stdout.on("data", (d) => {
       buf += d.toString();
@@ -21,23 +24,36 @@ function call(id) {
         if (!line.trim().startsWith("{")) continue;
         let msg;
         try { msg = JSON.parse(line); } catch { continue; }
+
+        // The id-1 reply, not a fixed sleep, is what says the server is ready.
+        if (msg.id === 1 && !toolCallSent) {
+          toolCallSent = true;
+          send({ jsonrpc: "2.0", method: "notifications/initialized" });
+          send({ jsonrpc: "2.0", id: 2, method: "tools/call", params: {
+            name: "airbnb_listing_details", arguments: { id, ignoreRobotsText: true } } });
+          continue;
+        }
+
         if (msg.id === 2) {
           clearTimeout(timer);
           proc.kill();
-          resolve(JSON.parse(msg.result.content[0].text));
+          if (msg.error) {
+            reject(new Error(`JSON-RPC error: ${JSON.stringify(msg.error)}`));
+            return;
+          }
+          const text = msg.result?.content?.[0]?.text;
+          if (!text) {
+            reject(new Error(`malformed tools/call response: ${JSON.stringify(msg)}`));
+            return;
+          }
+          resolve(JSON.parse(text));
         }
       }
     });
     proc.on("error", reject);
 
-    const send = (o) => proc.stdin.write(JSON.stringify(o) + "\n");
     send({ jsonrpc: "2.0", id: 1, method: "initialize", params: {
       protocolVersion: "2024-11-05", capabilities: {}, clientInfo: { name: "t", version: "1" } } });
-    setTimeout(() => {
-      send({ jsonrpc: "2.0", method: "notifications/initialized" });
-      send({ jsonrpc: "2.0", id: 2, method: "tools/call", params: {
-        name: "airbnb_listing_details", arguments: { id, ignoreRobotsText: true } } });
-    }, 700);
   });
 }
 

--- a/test-extension.js
+++ b/test-extension.js
@@ -24,7 +24,7 @@ class MCPTester {
 
   async startServer() {
     console.log('🚀 Starting MCP server...');
-    
+
     this.server = spawn('node', [SERVER_PATH, '--ignore-robots-txt'], {
       stdio: ['pipe', 'pipe', 'pipe'],
       env: { ...process.env, IGNORE_ROBOTS_TXT: 'true' }
@@ -34,13 +34,21 @@ class MCPTester {
       console.log('📋 Server log:', data.toString().trim());
     });
 
-    // Wait for server to start
-    await new Promise(resolve => setTimeout(resolve, 2000));
-    
     if (this.server.killed) {
       throw new Error('Server failed to start');
     }
-    
+
+    // Await the real initialize response instead of a fixed sleep.
+    const initResponse = await this.sendRequest('initialize', {
+      protocolVersion: '2024-11-05',
+      capabilities: {},
+      clientInfo: { name: 'test-extension', version: '1' },
+    });
+    if (initResponse.error) {
+      throw new Error(`initialize failed: ${initResponse.error.message}`);
+    }
+    this.server.stdin.write(JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' }) + '\n');
+
     console.log('✅ Server started successfully');
   }
 
@@ -260,6 +268,11 @@ class MCPTester {
           name: 'airbnb_search',
           arguments: { location: c.location, ignoreRobotsText: true },
         });
+        if (response.error) {
+          console.log(`   ❌ ${c.label}: JSON-RPC error: ${response.error.message || JSON.stringify(response.error)}`);
+          allOk = false;
+          continue;
+        }
         const url = this._extractSearchUrl(response);
         const bbox = parseBbox(url);
         if (!bbox) {

--- a/test/fixtures/pdp-presentation.json
+++ b/test/fixtures/pdp-presentation.json
@@ -32,7 +32,15 @@
               "highlights": [
                 { "title": "Dive right in", "subtitle": "This is one of the few places in the area with a pool." },
                 { "title": "Peace and quiet" }
-              ]
+              ],
+              "hostInfo": {
+                "passportData": {
+                  "name": "Nikolai",
+                  "titleText": "Superhost",
+                  "isSuperhost": true,
+                  "isVerified": true
+                }
+              }
             }
           }
         }
@@ -117,5 +125,109 @@
         }
       }]
     ]
+  },
+
+  "hostSuperhost": {
+    "_comment": "passportData.isSuperhost true — the live Superhost signal (MEET_YOUR_HOST is a stub).",
+    "niobeClientData": [
+      ["StaysPdpSectionsQuery", {
+        "data": {
+          "node": {
+            "pdpPresentation": {
+              "hostInfo": {
+                "passportData": {
+                  "name": "Lilia",
+                  "titleText": "Superhost",
+                  "isSuperhost": true
+                }
+              }
+            }
+          }
+        }
+      }]
+    ]
+  },
+
+  "hostNotSuperhost": {
+    "_comment": "passportData present with isSuperhost false.",
+    "niobeClientData": [
+      ["StaysPdpSectionsQuery", {
+        "data": {
+          "node": {
+            "pdpPresentation": {
+              "hostInfo": {
+                "passportData": {
+                  "name": "Alex",
+                  "titleText": "Host",
+                  "isSuperhost": false
+                }
+              }
+            }
+          }
+        }
+      }]
+    ]
+  },
+
+  "hostMissing": {
+    "_comment": "pdp present but no hostInfo — extractHostInfo must return null.",
+    "niobeClientData": [
+      ["StaysPdpSectionsQuery", {
+        "data": {
+          "node": {
+            "pdpPresentation": {
+              "highlights": [{ "title": "Quiet" }]
+            }
+          }
+        }
+      }]
+    ]
+  },
+
+  "hostWithStats": {
+    "_comment": "passportData with stats (Reviews/Rating) — projected when Airbnb provides them.",
+    "niobeClientData": [
+      ["StaysPdpSectionsQuery", {
+        "data": {
+          "node": {
+            "pdpPresentation": {
+              "hostInfo": {
+                "passportData": {
+                  "name": "Lilia",
+                  "titleText": "Superhost",
+                  "isSuperhost": true,
+                  "stats": [
+                    { "label": "Reviews", "value": "727" },
+                    { "label": "Rating", "value": "4.98" }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }]
+    ]
+  },
+
+  "hostWithoutStats": {
+    "_comment": "passportData without stats — extractHostInfo must omit the key, not emit null/empty.",
+    "niobeClientData": [
+      ["StaysPdpSectionsQuery", {
+        "data": {
+          "node": {
+            "pdpPresentation": {
+              "hostInfo": {
+                "passportData": {
+                  "name": "Sam",
+                  "titleText": "Superhost",
+                  "isSuperhost": true
+                }
+              }
+            }
+          }
+        }
+      }]
+    ]
   }
+
 }

--- a/test/fixtures/pdp-presentation.json
+++ b/test/fixtures/pdp-presentation.json
@@ -1,0 +1,121 @@
+{
+  "_comment": "Shapes of niobeClientData[i][1].data.node.pdpPresentation. 'healthy' is trimmed from a real listing payload; the others are synthesized to exercise specific edge cases. Real entries carry a string operation-name key at index 0, not null.",
+
+  "healthy": {
+    "niobeClientData": [
+      ["StaysPdpSectionsQuery", { "data": { "presentation": {} } }],
+      ["StaysPdpReviewsQuery", {
+        "data": {
+          "node": {
+            "pdpPresentation": {
+              "amenities": {
+                "title": "What this place offers",
+                "seeAllAmenitiesGroups": [
+                  {
+                    "__typename": "AmenityItemsGroup",
+                    "title": "Heating and cooling",
+                    "amenities": [
+                      { "available": true, "title": "Central air conditioning", "subtitle": { "text": "" } },
+                      { "available": true, "title": "Ceiling fan", "subtitle": { "text": "" } }
+                    ]
+                  },
+                  {
+                    "__typename": "AmenityItemsGroup",
+                    "title": "Not included",
+                    "amenities": [
+                      { "available": false, "title": "Dryer", "subtitle": { "text": "" } },
+                      { "available": false, "title": "Hot water", "subtitle": { "text": "" } }
+                    ]
+                  }
+                ]
+              },
+              "highlights": [
+                { "title": "Dive right in", "subtitle": "This is one of the few places in the area with a pool." },
+                { "title": "Peace and quiet" }
+              ]
+            }
+          }
+        }
+      }]
+    ]
+  },
+
+  "amenitiesOnly": {
+    "_comment": "Highlights have moved or vanished, amenities are fine. Partial extraction must still return the amenities.",
+    "niobeClientData": [
+      ["StaysPdpSectionsQuery", {
+        "data": {
+          "node": {
+            "pdpPresentation": {
+              "amenities": {
+                "title": "What this place offers",
+                "seeAllAmenitiesGroups": [
+                  {
+                    "title": "Heating and cooling",
+                    "amenities": [{ "available": true, "title": "AC - split type ductless system" }]
+                  }
+                ]
+              },
+              "highlights": null
+            }
+          }
+        }
+      }]
+    ]
+  },
+
+  "partiallyMalformedGroups": {
+    "_comment": "One amenity group is garbage. The healthy groups around it must survive.",
+    "niobeClientData": [
+      ["StaysPdpSectionsQuery", {
+        "data": {
+          "node": {
+            "pdpPresentation": {
+              "amenities": {
+                "seeAllAmenitiesGroups": [
+                  { "title": "Bathroom", "amenities": [{ "available": true, "title": "Hair dryer" }] },
+                  { "title": "Broken group", "amenities": "this should be an array" },
+                  { "title": "Kitchen", "amenities": [{ "available": true, "title": "Oven" }] }
+                ]
+              }
+            }
+          }
+        }
+      }]
+    ]
+  },
+
+  "noPdpBranch": {
+    "_comment": "Airbnb moved the branch again. Extraction must return null, not throw.",
+    "niobeClientData": [["StaysPdpSectionsQuery", { "data": { "presentation": {} } }]]
+  },
+
+  "subtitleShapes": {
+    "_comment": "Airbnb has shipped amenity and highlight subtitles as both a plain string and a { text } object. Both shapes must produce the same label.",
+    "niobeClientData": [
+      ["StaysPdpSectionsQuery", {
+        "data": {
+          "node": {
+            "pdpPresentation": {
+              "amenities": {
+                "seeAllAmenitiesGroups": [
+                  {
+                    "title": "Bathroom",
+                    "amenities": [
+                      { "available": true, "title": "Shampoo", "subtitle": "Body wash" },
+                      { "available": true, "title": "Hair dryer", "subtitle": { "text": "1200W" } }
+                    ]
+                  }
+                ]
+              },
+              "highlights": [
+                { "title": "Great location", "subtitle": "Walk to the beach" },
+                { "title": "Self check-in", "subtitle": { "text": "Check yourself in with the keypad." } }
+              ]
+            }
+          }
+        }
+      }]
+    ]
+  }
+}

--- a/test/fixtures/search-badges.json
+++ b/test/fixtures/search-badges.json
@@ -1,0 +1,66 @@
+{
+  "_comment": "Raw ExploreFormattedBadge shapes as they appear before pickBySchema. Includes the disagreement case: Guest favorite text + SUPERHOST type.",
+  "guestFavoriteButSuperhost": {
+    "demandStayListing": {
+      "id": "RGVtYW5kU3RheUxpc3Rpbmc6MzAzMjYzMTA=",
+      "description": {
+        "name": {
+          "localizedStringWithTranslationPreference": "Historic Condo"
+        }
+      },
+      "location": {
+        "coordinate": {
+          "latitude": 48.41,
+          "longitude": -114.34
+        }
+      }
+    },
+    "badges": [
+      {
+        "__typename": "ExploreFormattedBadge",
+        "text": "Guest favorite",
+        "loggingContext": {
+          "__typename": "ExploreFormattedBadgeLoggingContext",
+          "badgeType": "SUPERHOST"
+        },
+        "style": "LOUD_ROUNDED_PILL"
+      }
+    ],
+    "avgRatingA11yLabel": "4.98 out of 5 average rating, 727 reviews"
+  },
+  "superhostBadge": {
+    "demandStayListing": {
+      "id": "RGVtYW5kU3RheUxpc3Rpbmc6MTcyNDc2NTcwMTI3NzEwOTQwMA=="
+    },
+    "badges": [
+      {
+        "text": "Superhost",
+        "loggingContext": {
+          "badgeType": "SUPERHOST"
+        }
+      }
+    ]
+  },
+  "guestFavoriteOnly": {
+    "demandStayListing": {
+      "id": "RGVtYW5kU3RheUxpc3Rpbmc6NTEyNjcwMTk="
+    },
+    "badges": [
+      {
+        "text": "Guest favorite",
+        "loggingContext": {
+          "badgeType": "TOP_X_GUEST_FAVORITE"
+        }
+      }
+    ]
+  },
+  "textOnlyBadge": {
+    "_comment": "Older payload shape with text but no loggingContext \u2014 must still project text.",
+    "badges": [
+      {
+        "text": "Guest favorite",
+        "style": "PILL"
+      }
+    ]
+  }
+}

--- a/test/pdp.test.mjs
+++ b/test/pdp.test.mjs
@@ -1,0 +1,213 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import {
+  findPdpPresentation,
+  extractAmenities,
+  extractHighlights,
+  keyAmenityGroups,
+} from "../dist/util.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const fx = JSON.parse(
+  readFileSync(join(__dirname, "fixtures", "pdp-presentation.json"), "utf8")
+);
+
+test("findPdpPresentation locates the branch without hardcoding an index", () => {
+  assert.ok(findPdpPresentation(fx.healthy));
+  assert.equal(findPdpPresentation(fx.noPdpBranch), null);
+  assert.equal(findPdpPresentation({}), null);
+  assert.equal(findPdpPresentation(null), null);
+});
+
+test("extractAmenities passes through the section title", () => {
+  const out = extractAmenities(findPdpPresentation(fx.healthy));
+  assert.equal(out.title, "What this place offers");
+});
+
+test("an all-unavailable group is left unmarked; its title carries the meaning", () => {
+  const out = extractAmenities(findPdpPresentation(fx.healthy));
+  const heat = out.seeAllAmenitiesGroups.find((g) => g.title === "Heating and cooling");
+  const not = out.seeAllAmenitiesGroups.find((g) => g.title === "Not included");
+  assert.deepEqual(heat.amenities, ["Central air conditioning", "Ceiling fan"]);
+  // available:false is how Airbnb renders a struck-through amenity. The mechanism
+  // is availability homogeneity, not the group's title: a group where every item
+  // shares the same availability is left unmarked because the group's own name -
+  // whatever it is - already tells the story. Only a group mixing available and
+  // unavailable items needs its unavailable items called out individually. This
+  // fixture's homogeneous group happens to be titled "Not included", but that
+  // title is not what triggers the behavior - see the next test.
+  assert.deepEqual(not.amenities, ["Dryer", "Hot water"]);
+});
+
+test("a homogeneously-unavailable group is left unmarked under any title, not just 'Not included'", () => {
+  const pdp = {
+    amenities: {
+      seeAllAmenitiesGroups: [
+        {
+          title: "Kitchen extras",
+          amenities: [
+            { title: "Wine glasses", available: false },
+            { title: "Coffee maker", available: false },
+          ],
+        },
+      ],
+    },
+  };
+  const out = extractAmenities(pdp);
+  assert.deepEqual(out.seeAllAmenitiesGroups[0].amenities, ["Wine glasses", "Coffee maker"]);
+});
+
+test("a group mixing available and unavailable items marks the unavailable ones", () => {
+  const pdp = {
+    amenities: {
+      seeAllAmenitiesGroups: [
+        {
+          title: "Laundry",
+          amenities: [
+            { title: "Washer", available: true },
+            { title: "Dryer", available: false },
+          ],
+        },
+      ],
+    },
+  };
+  const out = extractAmenities(pdp);
+  assert.deepEqual(out.seeAllAmenitiesGroups[0].amenities, [
+    "Washer",
+    "Dryer — unavailable",
+  ]);
+});
+
+test("extractHighlights joins a subtitle onto its title when present", () => {
+  const out = extractHighlights(findPdpPresentation(fx.healthy));
+  assert.deepEqual(out.highlights, [
+    "Dive right in: This is one of the few places in the area with a pool.",
+    "Peace and quiet",
+  ]);
+});
+
+// --- partial extraction: one field failing must not cost the others ---
+
+test("amenities still extract when highlights are gone", () => {
+  const pdp = findPdpPresentation(fx.amenitiesOnly);
+  const amenities = extractAmenities(pdp);
+  assert.ok(amenities, "amenities must survive a missing highlights field");
+  assert.deepEqual(amenities.seeAllAmenitiesGroups[0].amenities, [
+    "AC - split type ductless system",
+  ]);
+  assert.equal(extractHighlights(pdp), null, "missing highlights report as null, not as an error");
+});
+
+test("a malformed amenity group does not destroy the healthy groups around it", () => {
+  const out = extractAmenities(findPdpPresentation(fx.partiallyMalformedGroups));
+  const titles = out.seeAllAmenitiesGroups.map((g) => g.title);
+  assert.ok(titles.includes("Bathroom"), "groups before the bad one must survive");
+  assert.ok(titles.includes("Kitchen"), "groups after the bad one must survive");
+  const bathroom = out.seeAllAmenitiesGroups.find((g) => g.title === "Bathroom");
+  assert.deepEqual(bathroom.amenities, ["Hair dryer"]);
+});
+
+test("extraction returns null rather than throwing when the branch moves", () => {
+  assert.equal(extractAmenities(null), null);
+  assert.equal(extractAmenities({}), null);
+  assert.equal(extractHighlights(null), null);
+  assert.equal(extractHighlights({}), null);
+});
+
+test("extractAmenities returns null when every group is empty", () => {
+  const pdp = {
+    amenities: {
+      seeAllAmenitiesGroups: [
+        { title: "Bathroom", amenities: [] },
+        { title: "Kitchen", amenities: [] },
+      ],
+    },
+  };
+  assert.equal(extractAmenities(pdp), null);
+});
+
+// --- subtitle shape: Airbnb has shipped this as both a plain string and a
+// { text } object, on both amenities and highlights. Both must label the same. ---
+
+test("extractAmenities labels a string subtitle and a { text } subtitle identically", () => {
+  const pdp = findPdpPresentation(fx.subtitleShapes);
+  const out = extractAmenities(pdp);
+  assert.deepEqual(out.seeAllAmenitiesGroups[0].amenities, [
+    "Shampoo (Body wash)",
+    "Hair dryer (1200W)",
+  ]);
+});
+
+test("extractHighlights labels a string subtitle and a { text } subtitle identically", () => {
+  const pdp = findPdpPresentation(fx.subtitleShapes);
+  const out = extractHighlights(pdp);
+  assert.deepEqual(out.highlights, [
+    "Great location: Walk to the beach",
+    "Self check-in: Check yourself in with the keypad.",
+  ]);
+});
+
+// --- keyAmenityGroups: no coverage at all before this branch ---
+
+test("keyAmenityGroups keys groups by title", () => {
+  const section = {
+    seeAllAmenitiesGroups: [
+      { title: "Bathroom", amenities: [{ title: "Hair dryer" }] },
+      { title: "Kitchen", amenities: [{ title: "Oven" }] },
+    ],
+  };
+  const out = keyAmenityGroups(section);
+  assert.deepEqual(out.seeAllAmenitiesGroups, {
+    Bathroom: [{ title: "Hair dryer" }],
+    Kitchen: [{ title: "Oven" }],
+  });
+});
+
+test("keyAmenityGroups falls back to 'Other' for an untitled group", () => {
+  const section = {
+    seeAllAmenitiesGroups: [{ amenities: [{ title: "Mystery item" }] }],
+  };
+  const out = keyAmenityGroups(section);
+  assert.deepEqual(out.seeAllAmenitiesGroups, { Other: [{ title: "Mystery item" }] });
+});
+
+test("keyAmenityGroups merges duplicate titles by concatenation, not overwrite", () => {
+  const section = {
+    seeAllAmenitiesGroups: [
+      { title: "Bathroom", amenities: [{ title: "Hair dryer" }] },
+      { title: "Bathroom", amenities: [{ title: "Shampoo" }] },
+    ],
+  };
+  const out = keyAmenityGroups(section);
+  assert.deepEqual(out.seeAllAmenitiesGroups.Bathroom, [
+    { title: "Hair dryer" },
+    { title: "Shampoo" },
+  ]);
+});
+
+test("keyAmenityGroups drops groups that have no amenities", () => {
+  const section = {
+    seeAllAmenitiesGroups: [
+      { title: "Bathroom", amenities: [] },
+      { title: "Kitchen", amenities: [{ title: "Oven" }] },
+    ],
+  };
+  const out = keyAmenityGroups(section);
+  assert.deepEqual(out.seeAllAmenitiesGroups, { Kitchen: [{ title: "Oven" }] });
+  assert.ok(!("Bathroom" in out.seeAllAmenitiesGroups));
+});
+
+test("keyAmenityGroups passes through non-matching objects, arrays, and null unchanged", () => {
+  assert.equal(keyAmenityGroups(null), null);
+  assert.equal(keyAmenityGroups(42), 42);
+
+  const arr = [1, 2, 3];
+  assert.equal(keyAmenityGroups(arr), arr);
+
+  const noGroups = { foo: "bar" };
+  assert.deepEqual(keyAmenityGroups(noGroups), noGroups);
+});

--- a/test/pdp.test.mjs
+++ b/test/pdp.test.mjs
@@ -9,6 +9,7 @@ import {
   extractAmenities,
   extractHighlights,
   keyAmenityGroups,
+  extractHostInfo,
 } from "../dist/util.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -116,6 +117,8 @@ test("extraction returns null rather than throwing when the branch moves", () =>
   assert.equal(extractAmenities({}), null);
   assert.equal(extractHighlights(null), null);
   assert.equal(extractHighlights({}), null);
+  assert.equal(extractHostInfo(null), null);
+  assert.equal(extractHostInfo({}), null);
 });
 
 test("extractAmenities returns null when every group is empty", () => {
@@ -211,3 +214,50 @@ test("keyAmenityGroups passes through non-matching objects, arrays, and null unc
   const noGroups = { foo: "bar" };
   assert.deepEqual(keyAmenityGroups(noGroups), noGroups);
 });
+
+// --- HOST Superhost recovery from pdpPresentation.hostInfo.passportData ---
+
+test("extractHostInfo surfaces isSuperhost from passportData", () => {
+  const out = extractHostInfo(findPdpPresentation(fx.hostSuperhost));
+  assert.deepEqual(out, {
+    isSuperhost: true,
+    name: "Lilia",
+    titleText: "Superhost",
+  });
+});
+
+test("extractHostInfo reports isSuperhost false when the host is not a Superhost", () => {
+  const out = extractHostInfo(findPdpPresentation(fx.hostNotSuperhost));
+  assert.equal(out.isSuperhost, false);
+  assert.equal(out.name, "Alex");
+});
+
+test("extractHostInfo returns null when hostInfo is absent", () => {
+  assert.equal(extractHostInfo(findPdpPresentation(fx.hostMissing)), null);
+  assert.equal(extractHostInfo(findPdpPresentation(fx.noPdpBranch)), null);
+});
+
+test("extractHostInfo reads Superhost off the healthy fixture hostInfo", () => {
+  const out = extractHostInfo(findPdpPresentation(fx.healthy));
+  assert.equal(out.isSuperhost, true);
+  assert.equal(out.name, "Nikolai");
+  assert.equal(out.titleText, "Superhost");
+});
+
+test("extractHostInfo includes stats when passportData carries Reviews/Rating", () => {
+  const out = extractHostInfo(findPdpPresentation(fx.hostWithStats));
+  assert.equal(out.isSuperhost, true);
+  assert.equal(out.name, "Lilia");
+  assert.deepEqual(out.stats, [
+    { label: "Reviews", value: "727" },
+    { label: "Rating", value: "4.98" },
+  ]);
+});
+
+test("extractHostInfo omits stats when passportData has none", () => {
+  const out = extractHostInfo(findPdpPresentation(fx.hostWithoutStats));
+  assert.equal(out.isSuperhost, true);
+  assert.equal(out.name, "Sam");
+  assert.equal(out.stats, undefined);
+});
+

--- a/test/util.test.mjs
+++ b/test/util.test.mjs
@@ -1,7 +1,31 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
 
-import { cleanObject, pickBySchema, flattenArraysInObject } from "../dist/util.js";
+import {
+  cleanObject,
+  pickBySchema,
+  flattenArraysInObject,
+  searchBadgeSchema,
+  extractBadgeType,
+} from "../dist/util.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const badgeFx = JSON.parse(
+  readFileSync(join(__dirname, "fixtures", "search-badges.json"), "utf8")
+);
+
+/** Full search-card pipeline: clean → extract type → pick → flatten → attach. */
+function projectSearchCard(raw) {
+  const clone = structuredClone(raw);
+  cleanObject(clone);
+  const badgeType = extractBadgeType(clone);
+  const flat = flattenArraysInObject(pickBySchema(clone, { badges: searchBadgeSchema }));
+  if (badgeType) flat.badgeType = badgeType;
+  return flat;
+}
 
 // The helpers amenity/highlight recovery is built on had no coverage at all.
 
@@ -35,4 +59,46 @@ test("flattenArraysInObject joins arrays of objects into a string", () => {
 
 test("flattenArraysInObject leaves primitives alone", () => {
   assert.deepEqual(flattenArraysInObject({ a: 1, b: "x" }), { a: 1, b: "x" });
+});
+
+// --- search badges: flattened text stays pre-fix; badgeType is a sibling key ---
+
+test("badge schema projects only text (badgeType never enters the flatten pipeline)", () => {
+  const raw = structuredClone(badgeFx.guestFavoriteButSuperhost);
+  cleanObject(raw);
+  const projected = pickBySchema(raw, { badges: searchBadgeSchema });
+  assert.deepEqual(projected.badges, [{ text: "Guest favorite" }]);
+  assert.equal(projected.badges[0].loggingContext, undefined);
+});
+
+test("flattened badges string is byte-identical to pre-fix Guest favorite output", () => {
+  // Pre-fix: badges: { text: true } → flatten → "Guest favorite".
+  // Superhost must NOT leak into that string (no "Guest favorite: SUPERHOST").
+  const out = projectSearchCard(badgeFx.guestFavoriteButSuperhost);
+  assert.equal(out.badges, "Guest favorite");
+  assert.equal(out.badgeType, "SUPERHOST");
+});
+
+test("extractBadgeType returns SUPERHOST and TOP_X_GUEST_FAVORITE types", () => {
+  for (const [key, expected] of [
+    ["superhostBadge", "SUPERHOST"],
+    ["guestFavoriteOnly", "TOP_X_GUEST_FAVORITE"],
+    ["guestFavoriteButSuperhost", "SUPERHOST"],
+  ]) {
+    const raw = structuredClone(badgeFx[key]);
+    cleanObject(raw);
+    assert.equal(extractBadgeType(raw), expected, key);
+  }
+});
+
+test("text-only badges flatten without a badgeType key", () => {
+  const out = projectSearchCard(badgeFx.textOnlyBadge);
+  assert.equal(out.badges, "Guest favorite");
+  assert.equal(out.badgeType, undefined);
+});
+
+test("extractBadgeType returns null when badges or loggingContext are absent", () => {
+  assert.equal(extractBadgeType(null), null);
+  assert.equal(extractBadgeType({}), null);
+  assert.equal(extractBadgeType({ badges: [{ text: "Guest favorite" }] }), null);
 });

--- a/test/util.test.mjs
+++ b/test/util.test.mjs
@@ -1,0 +1,38 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { cleanObject, pickBySchema, flattenArraysInObject } from "../dist/util.js";
+
+// The helpers amenity/highlight recovery is built on had no coverage at all.
+
+test("pickBySchema copies only the keys the schema names", () => {
+  const out = pickBySchema({ a: 1, b: 2, c: { d: 3, e: 4 } }, { a: true, c: { d: true } });
+  assert.deepEqual(out, { a: 1, c: { d: 3 } });
+});
+
+test("pickBySchema maps over arrays", () => {
+  const out = pickBySchema([{ a: 1, b: 2 }, { a: 3, b: 4 }], { a: true });
+  assert.deepEqual(out, [{ a: 1 }, { a: 3 }]);
+});
+
+test("pickBySchema returns an empty object when the source is empty", () => {
+  // This is why a stubbed section reads as "no data" rather than "extraction broke".
+  assert.deepEqual(pickBySchema({}, { a: true }), {});
+});
+
+test("cleanObject removes nulls and __typename in place", () => {
+  const o = { a: 1, b: null, __typename: "X", c: { d: null, __typename: "Y", e: 2 } };
+  cleanObject(o);
+  assert.deepEqual(o, { a: 1, c: { e: 2 } });
+});
+
+test("flattenArraysInObject joins arrays of objects into a string", () => {
+  assert.equal(
+    flattenArraysInObject({ items: [{ title: "a" }, { title: "b" }] }).items,
+    "a, b"
+  );
+});
+
+test("flattenArraysInObject leaves primitives alone", () => {
+  assert.deepEqual(flattenArraysInObject({ a: 1, b: "x" }), { a: 1, b: "x" });
+});

--- a/util.ts
+++ b/util.ts
@@ -48,6 +48,38 @@ export function pickBySchema(obj: any, schema: any): any {
   return result;
 }
 
+/**
+ * Projection for search-result badges through the flatten pipeline.
+ *
+ * Only `text` goes through pickBySchema → flattenArraysInObject so the flattened
+ * badges string stays byte-identical to pre-fix output (e.g. "Guest favorite").
+ * The machine-readable type is attached separately via extractBadgeType — same
+ * pattern as priceBreakdown: structured data rides alongside the flatten result,
+ * never inside it.
+ */
+export const searchBadgeSchema: Record<string, any> = {
+  text: true,
+};
+
+/**
+ * Pull the machine-readable badge type off a raw search result before flatten
+ * collapses the badge object into a string.
+ *
+ * Airbnb assigns one badge per card. Guest favorite often wins the displayed
+ * `text`, while `loggingContext.badgeType` still carries SUPERHOST /
+ * TOP_X_GUEST_FAVORITE / etc. Call before or after cleanObject (badgeType is not
+ * stripped). Returns null when no type is present.
+ */
+export function extractBadgeType(raw: any): string | null {
+  const badges = raw?.badges;
+  if (!Array.isArray(badges)) return null;
+  for (const badge of badges) {
+    const t = badge?.loggingContext?.badgeType;
+    if (typeof t === "string" && t.trim()) return t;
+  }
+  return null;
+}
+
 export function flattenArraysInObject(input: any, inArray: boolean = false): any {
   if (Array.isArray(input)) {
     // Process each item in the array with inArray=true so that any object
@@ -192,3 +224,48 @@ export function extractHighlights(pdp: any): any | null {
 
   return mapped.length ? { highlights: mapped } : null;
 }
+
+/**
+ * Host Superhost status (and optional passport stats) from
+ * pdpPresentation.hostInfo.passportData.
+ * MEET_YOUR_HOST sections arrive as stubs; the live boolean lives here.
+ * Returns null when the branch is absent or isSuperhost is not a boolean.
+ *
+ * `stats` (Reviews / Rating / …) is projected when Airbnb includes it on the
+ * hostInfo branch — as `passportData.stats` or `hostInfo.stats`. Each entry is
+ * `{ label, value }`; malformed items are skipped rather than poisoning the rest.
+ */
+export function extractHostInfo(pdp: any): any | null {
+  const hostInfo = pdp?.hostInfo;
+  const passport = hostInfo?.passportData;
+  if (!passport || typeof passport !== "object") return null;
+  if (typeof passport.isSuperhost !== "boolean") return null;
+
+  const out: Record<string, any> = { isSuperhost: passport.isSuperhost };
+  if (typeof passport.name === "string" && passport.name.trim()) out.name = passport.name;
+  if (typeof passport.titleText === "string" && passport.titleText.trim()) {
+    out.titleText = passport.titleText;
+  }
+
+  const rawStats = Array.isArray(passport.stats)
+    ? passport.stats
+    : Array.isArray(hostInfo?.stats)
+      ? hostInfo.stats
+      : null;
+  if (rawStats) {
+    const stats = rawStats
+      .map((s: any) => {
+        if (!s || typeof s !== "object") return null;
+        const label = typeof s.label === "string" ? s.label : null;
+        const value =
+          typeof s.value === "string" || typeof s.value === "number" ? s.value : null;
+        if (label == null || value == null) return null;
+        return { label, value: String(value) };
+      })
+      .filter(Boolean);
+    if (stats.length) out.stats = stats;
+  }
+
+  return out;
+}
+


### PR DESCRIPTION
Fixes #24.

`airbnb_search` and `airbnb_listing_details` both had Superhost data in the
raw Airbnb payload and both dropped it before returning:

1. **Search** — `allowSearchResultSchema.badges` only projected `{ text: true }`.
   Airbnb assigns one badge per card, and Guest favorite wins over Superhost,
   so a Superhost listing often surfaces as `"Guest favorite"` with no type.
   The machine-readable `loggingContext.badgeType` (`SUPERHOST`,
   `TOP_X_GUEST_FAVORITE`, …) was present and discarded.

2. **Details** — Superhost does not live usefully on `MEET_YOUR_HOST` (that
   section is a stub today). It lives on
   `pdpPresentation.hostInfo.passportData.isSuperhost` (and related passport
   fields), which the tool never projected. Issue evidence also shows a
   `stats` array (Reviews / Rating) on the host section when Airbnb provides it.

## Approach

Output-only; no new tool parameters.

- Keep `searchBadgeSchema` as `{ text: true }` so the flattened `badges` string
  stays byte-identical to pre-fix output (e.g. `"Guest favorite"` — not
  `"Guest favorite: SUPERHOST"`).
- Attach the machine-readable type as a **sibling key** on the result card
  (`badgeType: "SUPERHOST"`) after flatten, via `extractBadgeType` — same
  attach-after-flatten pattern this repo uses for `priceBreakdown`.
- Add `extractHostInfo(pdp)` (same small pure-extractor style as
  `extractAmenities` / `extractHighlights`): returns
  `{ isSuperhost, name?, titleText?, stats? }` or `null` when passport data is
  absent. `stats` is an array of `{ label, value }` when present on the
  hostInfo branch (`passportData.stats` or `hostInfo.stats`); omitted otherwise.
  Live payloads may not always carry stats — they surface when Airbnb provides them.
- Wire an additive `HOST` detail entry from that extractor.

## Tests

Offline fixture suite (`npm test`):

- Search: flattened badges string remains exactly `"Guest favorite"` while
  `badgeType: "SUPERHOST"` is attached as its own key; `TOP_X_GUEST_FAVORITE`
  and text-only badges; extractBadgeType null when loggingContext is absent.
- Details: `extractHostInfo` true/false/absent; Superhost on the healthy PDP
  fixture; null when branch missing; stats present and stats omitted fixtures.

Revert-proof (stub, not full-file restore): temporarily stub
`searchBadgeSchema` to `{ text: true }`, `extractBadgeType` to always return
`null`, and `extractHostInfo` to always return `null` in the built
`dist/util.js`, then run `node --test test/*.test.mjs` (no rebuild). That
yields **assertion-level** failures matching the issue symptom — Superhost
signal absent (`badgeType` undefined / `extractHostInfo` returns null) —
**7 fail / 27 pass**. Restore the real `dist/util.js` → **34 pass / 0 fail**.

## Verification

    $ npm test
    ℹ tests 34
    ℹ pass 34
    ℹ fail 0

Spot-check on a live Superhost listing (e.g. id `30326310`): raw
`passportData.isSuperhost: true` / titleText Superhost while pre-fix MCP
search returned badges `"Guest favorite"` only (no `badgeType`) and MCP
details contained no Superhost signal. Base projection of
`{text:"Guest favorite", loggingContext:{badgeType:"SUPERHOST"}}` under
`{ text: true }` drops to `{text:"Guest favorite"}` — gap still holds without
the post-flatten `badgeType` attach.
