### PR TITLE
fix: highlights recovery from #42 never matched the live field names

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,11 +244,18 @@ npm run watch
 ### Testing
 
 ```bash
-# Build, then run both suites
+# Build, then run the offline suite
 npm test
 ```
 
-`npm test` drives the built server over stdio and calls the tools for real:
+`npm test` runs the fixture-backed unit suite under `test/*.test.mjs` — no network access, safe for CI and for every install.
+
+```bash
+# Build, then drive the built server over stdio against the real site
+npm run test:live
+```
+
+`npm run test:live` calls the tools for real:
 
 - `test-extension.js` — MCP handshake, tool listing, a search, listing details, and the geocoding paths (Photon, Nominatim fallback)
 - `test-amenities.js` — amenity extraction across several live listings, checking that amenities Airbnb strikes through never appear as ones the listing offers

--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
     "prepare": "npm run build",
     "version": "node sync-version.js && git add manifest.json",
     "pretest": "npm run build",
-    "test": "node test-extension.js && node test-amenities.js",
+    "test": "node --test test/*.test.mjs",
+    "pretest:live": "npm run build",
+    "test:live": "node test-extension.js && node test-amenities.js",
     "watch": "tsc --watch",
     "sync-version": "node sync-version.js"
   },

--- a/test-amenities.js
+++ b/test-amenities.js
@@ -13,7 +13,10 @@ function call(id) {
       stdio: ["pipe", "pipe", "pipe"],
     });
     let buf = "";
+    let toolCallSent = false;
     const timer = setTimeout(() => { proc.kill(); reject(new Error("timeout")); }, 60000);
+
+    const send = (o) => proc.stdin.write(JSON.stringify(o) + "\n");
 
     proc.stdout.on("data", (d) => {
       buf += d.toString();
@@ -21,23 +24,36 @@ function call(id) {
         if (!line.trim().startsWith("{")) continue;
         let msg;
         try { msg = JSON.parse(line); } catch { continue; }
+
+        // The id-1 reply, not a fixed sleep, is what says the server is ready.
+        if (msg.id === 1 && !toolCallSent) {
+          toolCallSent = true;
+          send({ jsonrpc: "2.0", method: "notifications/initialized" });
+          send({ jsonrpc: "2.0", id: 2, method: "tools/call", params: {
+            name: "airbnb_listing_details", arguments: { id, ignoreRobotsText: true } } });
+          continue;
+        }
+
         if (msg.id === 2) {
           clearTimeout(timer);
           proc.kill();
-          resolve(JSON.parse(msg.result.content[0].text));
+          if (msg.error) {
+            reject(new Error(`JSON-RPC error: ${JSON.stringify(msg.error)}`));
+            return;
+          }
+          const text = msg.result?.content?.[0]?.text;
+          if (!text) {
+            reject(new Error(`malformed tools/call response: ${JSON.stringify(msg)}`));
+            return;
+          }
+          resolve(JSON.parse(text));
         }
       }
     });
     proc.on("error", reject);
 
-    const send = (o) => proc.stdin.write(JSON.stringify(o) + "\n");
     send({ jsonrpc: "2.0", id: 1, method: "initialize", params: {
       protocolVersion: "2024-11-05", capabilities: {}, clientInfo: { name: "t", version: "1" } } });
-    setTimeout(() => {
-      send({ jsonrpc: "2.0", method: "notifications/initialized" });
-      send({ jsonrpc: "2.0", id: 2, method: "tools/call", params: {
-        name: "airbnb_listing_details", arguments: { id, ignoreRobotsText: true } } });
-    }, 700);
   });
 }
 

--- a/test-extension.js
+++ b/test-extension.js
@@ -24,7 +24,7 @@ class MCPTester {
 
   async startServer() {
     console.log('🚀 Starting MCP server...');
-    
+
     this.server = spawn('node', [SERVER_PATH, '--ignore-robots-txt'], {
       stdio: ['pipe', 'pipe', 'pipe'],
       env: { ...process.env, IGNORE_ROBOTS_TXT: 'true' }
@@ -34,13 +34,21 @@ class MCPTester {
       console.log('📋 Server log:', data.toString().trim());
     });
 
-    // Wait for server to start
-    await new Promise(resolve => setTimeout(resolve, 2000));
-    
     if (this.server.killed) {
       throw new Error('Server failed to start');
     }
-    
+
+    // Await the real initialize response instead of a fixed sleep.
+    const initResponse = await this.sendRequest('initialize', {
+      protocolVersion: '2024-11-05',
+      capabilities: {},
+      clientInfo: { name: 'test-extension', version: '1' },
+    });
+    if (initResponse.error) {
+      throw new Error(`initialize failed: ${initResponse.error.message}`);
+    }
+    this.server.stdin.write(JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' }) + '\n');
+
     console.log('✅ Server started successfully');
   }
 
@@ -260,6 +268,11 @@ class MCPTester {
           name: 'airbnb_search',
           arguments: { location: c.location, ignoreRobotsText: true },
         });
+        if (response.error) {
+          console.log(`   ❌ ${c.label}: JSON-RPC error: ${response.error.message || JSON.stringify(response.error)}`);
+          allOk = false;
+          continue;
+        }
         const url = this._extractSearchUrl(response);
         const bbox = parseBbox(url);
         if (!bbox) {

--- a/test/fixtures/pdp-presentation.json
+++ b/test/fixtures/pdp-presentation.json
@@ -117,5 +117,67 @@
         }
       }]
     ]
+  },
+
+  "highlightsNewShape": {
+    "_comment": "Live payload shape observed 2025-08 on listing 53610715: headline/body are { __typename: 'LocalizedContent', localizedContent: '...' } objects, not plain strings.",
+    "niobeClientData": [
+      ["StaysPdpSectionsQuery", {
+        "data": {
+          "node": {
+            "pdpPresentation": {
+              "highlights": [
+                {
+                  "__typename": "ListingPdpHighlight",
+                  "type": "LISTING_GUEST_FAVORITE",
+                  "headline": { "__typename": "LocalizedContent", "localizedContent": "Top 10% of homes" },
+                  "body": { "__typename": "LocalizedContent", "localizedContent": "This home is highly ranked based on ratings, reviews, and reliability." },
+                  "icon": { "__typename": "IconWrapper", "iconContent": "SYSTEM_GOLDEN_TROPHY" }
+                },
+                {
+                  "__typename": "ListingPdpHighlight",
+                  "type": "POOL",
+                  "headline": { "__typename": "LocalizedContent", "localizedContent": "Dive right in" },
+                  "body": { "__typename": "LocalizedContent", "localizedContent": "This is one of the few places in the area with a pool." },
+                  "icon": { "__typename": "IconWrapper", "iconContent": "SYSTEM_POOL" }
+                },
+                {
+                  "__typename": "ListingPdpHighlight",
+                  "type": "QUIET",
+                  "headline": { "__typename": "LocalizedContent", "localizedContent": "Peace and quiet" },
+                  "icon": { "__typename": "IconWrapper", "iconContent": "SYSTEM_QUIET" }
+                },
+                {
+                  "__typename": "ListingPdpHighlight",
+                  "type": "PARKING",
+                  "headline": { "__typename": "LocalizedContent", "localizedContent": "Free parking" },
+                  "body": { "__typename": "LocalizedContent", "localizedContent": "Free parking on premises" },
+                  "icon": { "__typename": "IconWrapper", "iconContent": "SYSTEM_PARKING" }
+                }
+              ]
+            }
+          }
+        }
+      }]
+    ]
+  },
+
+  "highlightsMixed": {
+    "_comment": "Edge cases: one item has neither headline nor title (must be skipped), one has headline only, one has title only (legacy). Tests that both shapes coexist and the null-title guard still fires.",
+    "niobeClientData": [
+      ["StaysPdpSectionsQuery", {
+        "data": {
+          "node": {
+            "pdpPresentation": {
+              "highlights": [
+                { "__typename": "PdpHighlight", "type": "UNKNOWN" },
+                { "headline": "Great for families" },
+                { "title": "Superhost" }
+              ]
+            }
+          }
+        }
+      }]
+    ]
   }
 }

--- a/test/fixtures/pdp-presentation.json
+++ b/test/fixtures/pdp-presentation.json
@@ -1,0 +1,121 @@
+{
+  "_comment": "Shapes of niobeClientData[i][1].data.node.pdpPresentation. 'healthy' is trimmed from a real listing payload; the others are synthesized to exercise specific edge cases. Real entries carry a string operation-name key at index 0, not null.",
+
+  "healthy": {
+    "niobeClientData": [
+      ["StaysPdpSectionsQuery", { "data": { "presentation": {} } }],
+      ["StaysPdpReviewsQuery", {
+        "data": {
+          "node": {
+            "pdpPresentation": {
+              "amenities": {
+                "title": "What this place offers",
+                "seeAllAmenitiesGroups": [
+                  {
+                    "__typename": "AmenityItemsGroup",
+                    "title": "Heating and cooling",
+                    "amenities": [
+                      { "available": true, "title": "Central air conditioning", "subtitle": { "text": "" } },
+                      { "available": true, "title": "Ceiling fan", "subtitle": { "text": "" } }
+                    ]
+                  },
+                  {
+                    "__typename": "AmenityItemsGroup",
+                    "title": "Not included",
+                    "amenities": [
+                      { "available": false, "title": "Dryer", "subtitle": { "text": "" } },
+                      { "available": false, "title": "Hot water", "subtitle": { "text": "" } }
+                    ]
+                  }
+                ]
+              },
+              "highlights": [
+                { "title": "Dive right in", "subtitle": "This is one of the few places in the area with a pool." },
+                { "title": "Peace and quiet" }
+              ]
+            }
+          }
+        }
+      }]
+    ]
+  },
+
+  "amenitiesOnly": {
+    "_comment": "Highlights have moved or vanished, amenities are fine. Partial extraction must still return the amenities.",
+    "niobeClientData": [
+      ["StaysPdpSectionsQuery", {
+        "data": {
+          "node": {
+            "pdpPresentation": {
+              "amenities": {
+                "title": "What this place offers",
+                "seeAllAmenitiesGroups": [
+                  {
+                    "title": "Heating and cooling",
+                    "amenities": [{ "available": true, "title": "AC - split type ductless system" }]
+                  }
+                ]
+              },
+              "highlights": null
+            }
+          }
+        }
+      }]
+    ]
+  },
+
+  "partiallyMalformedGroups": {
+    "_comment": "One amenity group is garbage. The healthy groups around it must survive.",
+    "niobeClientData": [
+      ["StaysPdpSectionsQuery", {
+        "data": {
+          "node": {
+            "pdpPresentation": {
+              "amenities": {
+                "seeAllAmenitiesGroups": [
+                  { "title": "Bathroom", "amenities": [{ "available": true, "title": "Hair dryer" }] },
+                  { "title": "Broken group", "amenities": "this should be an array" },
+                  { "title": "Kitchen", "amenities": [{ "available": true, "title": "Oven" }] }
+                ]
+              }
+            }
+          }
+        }
+      }]
+    ]
+  },
+
+  "noPdpBranch": {
+    "_comment": "Airbnb moved the branch again. Extraction must return null, not throw.",
+    "niobeClientData": [["StaysPdpSectionsQuery", { "data": { "presentation": {} } }]]
+  },
+
+  "subtitleShapes": {
+    "_comment": "Airbnb has shipped amenity and highlight subtitles as both a plain string and a { text } object. Both shapes must produce the same label.",
+    "niobeClientData": [
+      ["StaysPdpSectionsQuery", {
+        "data": {
+          "node": {
+            "pdpPresentation": {
+              "amenities": {
+                "seeAllAmenitiesGroups": [
+                  {
+                    "title": "Bathroom",
+                    "amenities": [
+                      { "available": true, "title": "Shampoo", "subtitle": "Body wash" },
+                      { "available": true, "title": "Hair dryer", "subtitle": { "text": "1200W" } }
+                    ]
+                  }
+                ]
+              },
+              "highlights": [
+                { "title": "Great location", "subtitle": "Walk to the beach" },
+                { "title": "Self check-in", "subtitle": { "text": "Check yourself in with the keypad." } }
+              ]
+            }
+          }
+        }
+      }]
+    ]
+  }
+}

--- a/test/pdp.test.mjs
+++ b/test/pdp.test.mjs
@@ -1,0 +1,213 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import {
+  findPdpPresentation,
+  extractAmenities,
+  extractHighlights,
+  keyAmenityGroups,
+} from "../dist/util.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const fx = JSON.parse(
+  readFileSync(join(__dirname, "fixtures", "pdp-presentation.json"), "utf8")
+);
+
+test("findPdpPresentation locates the branch without hardcoding an index", () => {
+  assert.ok(findPdpPresentation(fx.healthy));
+  assert.equal(findPdpPresentation(fx.noPdpBranch), null);
+  assert.equal(findPdpPresentation({}), null);
+  assert.equal(findPdpPresentation(null), null);
+});
+
+test("extractAmenities passes through the section title", () => {
+  const out = extractAmenities(findPdpPresentation(fx.healthy));
+  assert.equal(out.title, "What this place offers");
+});
+
+test("an all-unavailable group is left unmarked; its title carries the meaning", () => {
+  const out = extractAmenities(findPdpPresentation(fx.healthy));
+  const heat = out.seeAllAmenitiesGroups.find((g) => g.title === "Heating and cooling");
+  const not = out.seeAllAmenitiesGroups.find((g) => g.title === "Not included");
+  assert.deepEqual(heat.amenities, ["Central air conditioning", "Ceiling fan"]);
+  // available:false is how Airbnb renders a struck-through amenity. The mechanism
+  // is availability homogeneity, not the group's title: a group where every item
+  // shares the same availability is left unmarked because the group's own name -
+  // whatever it is - already tells the story. Only a group mixing available and
+  // unavailable items needs its unavailable items called out individually. This
+  // fixture's homogeneous group happens to be titled "Not included", but that
+  // title is not what triggers the behavior - see the next test.
+  assert.deepEqual(not.amenities, ["Dryer", "Hot water"]);
+});
+
+test("a homogeneously-unavailable group is left unmarked under any title, not just 'Not included'", () => {
+  const pdp = {
+    amenities: {
+      seeAllAmenitiesGroups: [
+        {
+          title: "Kitchen extras",
+          amenities: [
+            { title: "Wine glasses", available: false },
+            { title: "Coffee maker", available: false },
+          ],
+        },
+      ],
+    },
+  };
+  const out = extractAmenities(pdp);
+  assert.deepEqual(out.seeAllAmenitiesGroups[0].amenities, ["Wine glasses", "Coffee maker"]);
+});
+
+test("a group mixing available and unavailable items marks the unavailable ones", () => {
+  const pdp = {
+    amenities: {
+      seeAllAmenitiesGroups: [
+        {
+          title: "Laundry",
+          amenities: [
+            { title: "Washer", available: true },
+            { title: "Dryer", available: false },
+          ],
+        },
+      ],
+    },
+  };
+  const out = extractAmenities(pdp);
+  assert.deepEqual(out.seeAllAmenitiesGroups[0].amenities, [
+    "Washer",
+    "Dryer — unavailable",
+  ]);
+});
+
+test("extractHighlights joins a subtitle onto its title when present", () => {
+  const out = extractHighlights(findPdpPresentation(fx.healthy));
+  assert.deepEqual(out.highlights, [
+    "Dive right in: This is one of the few places in the area with a pool.",
+    "Peace and quiet",
+  ]);
+});
+
+// --- partial extraction: one field failing must not cost the others ---
+
+test("amenities still extract when highlights are gone", () => {
+  const pdp = findPdpPresentation(fx.amenitiesOnly);
+  const amenities = extractAmenities(pdp);
+  assert.ok(amenities, "amenities must survive a missing highlights field");
+  assert.deepEqual(amenities.seeAllAmenitiesGroups[0].amenities, [
+    "AC - split type ductless system",
+  ]);
+  assert.equal(extractHighlights(pdp), null, "missing highlights report as null, not as an error");
+});
+
+test("a malformed amenity group does not destroy the healthy groups around it", () => {
+  const out = extractAmenities(findPdpPresentation(fx.partiallyMalformedGroups));
+  const titles = out.seeAllAmenitiesGroups.map((g) => g.title);
+  assert.ok(titles.includes("Bathroom"), "groups before the bad one must survive");
+  assert.ok(titles.includes("Kitchen"), "groups after the bad one must survive");
+  const bathroom = out.seeAllAmenitiesGroups.find((g) => g.title === "Bathroom");
+  assert.deepEqual(bathroom.amenities, ["Hair dryer"]);
+});
+
+test("extraction returns null rather than throwing when the branch moves", () => {
+  assert.equal(extractAmenities(null), null);
+  assert.equal(extractAmenities({}), null);
+  assert.equal(extractHighlights(null), null);
+  assert.equal(extractHighlights({}), null);
+});
+
+test("extractAmenities returns null when every group is empty", () => {
+  const pdp = {
+    amenities: {
+      seeAllAmenitiesGroups: [
+        { title: "Bathroom", amenities: [] },
+        { title: "Kitchen", amenities: [] },
+      ],
+    },
+  };
+  assert.equal(extractAmenities(pdp), null);
+});
+
+// --- subtitle shape: Airbnb has shipped this as both a plain string and a
+// { text } object, on both amenities and highlights. Both must label the same. ---
+
+test("extractAmenities labels a string subtitle and a { text } subtitle identically", () => {
+  const pdp = findPdpPresentation(fx.subtitleShapes);
+  const out = extractAmenities(pdp);
+  assert.deepEqual(out.seeAllAmenitiesGroups[0].amenities, [
+    "Shampoo (Body wash)",
+    "Hair dryer (1200W)",
+  ]);
+});
+
+test("extractHighlights labels a string subtitle and a { text } subtitle identically", () => {
+  const pdp = findPdpPresentation(fx.subtitleShapes);
+  const out = extractHighlights(pdp);
+  assert.deepEqual(out.highlights, [
+    "Great location: Walk to the beach",
+    "Self check-in: Check yourself in with the keypad.",
+  ]);
+});
+
+// --- keyAmenityGroups: no coverage at all before this branch ---
+
+test("keyAmenityGroups keys groups by title", () => {
+  const section = {
+    seeAllAmenitiesGroups: [
+      { title: "Bathroom", amenities: [{ title: "Hair dryer" }] },
+      { title: "Kitchen", amenities: [{ title: "Oven" }] },
+    ],
+  };
+  const out = keyAmenityGroups(section);
+  assert.deepEqual(out.seeAllAmenitiesGroups, {
+    Bathroom: [{ title: "Hair dryer" }],
+    Kitchen: [{ title: "Oven" }],
+  });
+});
+
+test("keyAmenityGroups falls back to 'Other' for an untitled group", () => {
+  const section = {
+    seeAllAmenitiesGroups: [{ amenities: [{ title: "Mystery item" }] }],
+  };
+  const out = keyAmenityGroups(section);
+  assert.deepEqual(out.seeAllAmenitiesGroups, { Other: [{ title: "Mystery item" }] });
+});
+
+test("keyAmenityGroups merges duplicate titles by concatenation, not overwrite", () => {
+  const section = {
+    seeAllAmenitiesGroups: [
+      { title: "Bathroom", amenities: [{ title: "Hair dryer" }] },
+      { title: "Bathroom", amenities: [{ title: "Shampoo" }] },
+    ],
+  };
+  const out = keyAmenityGroups(section);
+  assert.deepEqual(out.seeAllAmenitiesGroups.Bathroom, [
+    { title: "Hair dryer" },
+    { title: "Shampoo" },
+  ]);
+});
+
+test("keyAmenityGroups drops groups that have no amenities", () => {
+  const section = {
+    seeAllAmenitiesGroups: [
+      { title: "Bathroom", amenities: [] },
+      { title: "Kitchen", amenities: [{ title: "Oven" }] },
+    ],
+  };
+  const out = keyAmenityGroups(section);
+  assert.deepEqual(out.seeAllAmenitiesGroups, { Kitchen: [{ title: "Oven" }] });
+  assert.ok(!("Bathroom" in out.seeAllAmenitiesGroups));
+});
+
+test("keyAmenityGroups passes through non-matching objects, arrays, and null unchanged", () => {
+  assert.equal(keyAmenityGroups(null), null);
+  assert.equal(keyAmenityGroups(42), 42);
+
+  const arr = [1, 2, 3];
+  assert.equal(keyAmenityGroups(arr), arr);
+
+  const noGroups = { foo: "bar" };
+  assert.deepEqual(keyAmenityGroups(noGroups), noGroups);
+});

--- a/test/pdp.test.mjs
+++ b/test/pdp.test.mjs
@@ -211,3 +211,80 @@ test("keyAmenityGroups passes through non-matching objects, arrays, and null unc
   const noGroups = { foo: "bar" };
   assert.deepEqual(keyAmenityGroups(noGroups), noGroups);
 });
+
+// --- Airbnb now ships headline/body instead of title/subtitle.
+// Both shapes must be accepted. ---
+
+test("extractHighlights maps the new headline/body shape (nested LocalizedContent) correctly", () => {
+  const out = extractHighlights(findPdpPresentation(fx.highlightsNewShape));
+  assert.ok(out, "expected highlights, got null");
+  assert.deepEqual(out.highlights, [
+    "Top 10% of homes: This home is highly ranked based on ratings, reviews, and reliability.",
+    "Dive right in: This is one of the few places in the area with a pool.",
+    "Peace and quiet",
+    "Free parking: Free parking on premises",
+  ]);
+});
+
+test("extractHighlights still maps the legacy title/subtitle shape (no regression)", () => {
+  const out = extractHighlights(findPdpPresentation(fx.healthy));
+  assert.deepEqual(out.highlights, [
+    "Dive right in: This is one of the few places in the area with a pool.",
+    "Peace and quiet",
+  ]);
+});
+
+test("extractHighlights handles body as a { text } object", () => {
+  const pdp = { highlights: [
+    { headline: "Self check-in", body: { text: "Check yourself in with the lockbox." } },
+  ] };
+  const out = extractHighlights(pdp);
+  assert.ok(out, "expected highlights, got null");
+  assert.deepEqual(out.highlights, ["Self check-in: Check yourself in with the lockbox."]);
+});
+
+test("extractHighlights ignores non-string localized values instead of stringifying them", () => {
+  const pdp = { highlights: [
+    { headline: { localizedContent: { text: "nested" } }, title: "Superhost", body: "Great host" },
+    { headline: { localizedContent: ["a", "b"] } },
+  ] };
+  const out = extractHighlights(pdp);
+  assert.deepEqual(out.highlights, ["Superhost: Great host"]);
+});
+
+test("extractHighlights treats an empty new-shape value as missing and falls back to the legacy key", () => {
+  const pdp = { highlights: [
+    { headline: "", title: "Superhost", body: "", subtitle: "Great host" },
+  ] };
+  const out = extractHighlights(pdp);
+  assert.deepEqual(out.highlights, ["Superhost: Great host"]);
+});
+
+test("extractHighlights output is always plain strings, never raw GraphQL objects", () => {
+  // Regression guard: the previous code returned LocalizedContent objects instead
+  // of extracting .localizedContent, so the output contained __typename keys.
+  for (const key of ["highlightsNewShape", "healthy", "subtitleShapes", "highlightsMixed"]) {
+    const pdp = findPdpPresentation(fx[key]);
+    const out = extractHighlights(pdp);
+    assert.ok(out, `${key} must yield highlights`);
+    for (const h of out.highlights) {
+      assert.equal(typeof h, "string", `highlight in ${key} must be a string, got: ${JSON.stringify(h)}`);
+      assert.ok(!h.includes("__typename"), `highlight in ${key} must not contain __typename: ${h}`);
+    }
+  }
+});
+
+test("extractHighlights skips items missing both headline and title (no 'null: ...' string)", () => {
+  const out = extractHighlights(findPdpPresentation(fx.highlightsMixed));
+  assert.deepEqual(out.highlights, ["Great for families", "Superhost"]);
+  for (const h of out.highlights) {
+    assert.ok(!h.startsWith("null"), `must never produce a "null: ..." string, got: ${h}`);
+  }
+});
+
+test("extractHighlights returns null for empty and absent highlights", () => {
+  assert.equal(extractHighlights({ highlights: [] }), null);
+  assert.equal(extractHighlights({ highlights: null }), null);
+  assert.equal(extractHighlights({}), null);
+  assert.equal(extractHighlights(null), null);
+});

--- a/test/util.test.mjs
+++ b/test/util.test.mjs
@@ -1,0 +1,38 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { cleanObject, pickBySchema, flattenArraysInObject } from "../dist/util.js";
+
+// The helpers amenity/highlight recovery is built on had no coverage at all.
+
+test("pickBySchema copies only the keys the schema names", () => {
+  const out = pickBySchema({ a: 1, b: 2, c: { d: 3, e: 4 } }, { a: true, c: { d: true } });
+  assert.deepEqual(out, { a: 1, c: { d: 3 } });
+});
+
+test("pickBySchema maps over arrays", () => {
+  const out = pickBySchema([{ a: 1, b: 2 }, { a: 3, b: 4 }], { a: true });
+  assert.deepEqual(out, [{ a: 1 }, { a: 3 }]);
+});
+
+test("pickBySchema returns an empty object when the source is empty", () => {
+  // This is why a stubbed section reads as "no data" rather than "extraction broke".
+  assert.deepEqual(pickBySchema({}, { a: true }), {});
+});
+
+test("cleanObject removes nulls and __typename in place", () => {
+  const o = { a: 1, b: null, __typename: "X", c: { d: null, __typename: "Y", e: 2 } };
+  cleanObject(o);
+  assert.deepEqual(o, { a: 1, c: { e: 2 } });
+});
+
+test("flattenArraysInObject joins arrays of objects into a string", () => {
+  assert.equal(
+    flattenArraysInObject({ items: [{ title: "a" }, { title: "b" }] }).items,
+    "a, b"
+  );
+});
+
+test("flattenArraysInObject leaves primitives alone", () => {
+  assert.deepEqual(flattenArraysInObject({ a: 1, b: "x" }), { a: 1, b: "x" });
+});

--- a/util.ts
+++ b/util.ts
@@ -175,17 +175,26 @@ export function keyAmenityGroups(section: any): any {
   return { ...section, seeAllAmenitiesGroups: keyed };
 }
 
+// Normalize a localized field to its string across all known shapes:
+// plain string | { localizedContent } | { text }
+function localizedStr(v: any): string | undefined {
+  const s = typeof v === "string" ? v : v?.localizedContent ?? v?.text;
+  // Anything non-string would stringify to "[object Object]" downstream; an empty
+  // string must read as missing so the legacy key below still gets its turn.
+  return typeof s === "string" && s !== "" ? s : undefined;
+}
+
 export function extractHighlights(pdp: any): any | null {
   const highlights = pdp?.highlights;
   if (!Array.isArray(highlights) || highlights.length === 0) return null;
   const mapped = highlights
     .map((h: any) => {
-      const title = h?.title;
+      // Live payloads now use headline/body; older ones used title/subtitle. Accept both.
+      const title = localizedStr(h?.headline) ?? localizedStr(h?.title);
       // Interpolating first would turn a missing title into the literal string
       // "null: Free parking on premises", which .filter(Boolean) cannot catch.
       if (!title) return null;
-      // Airbnb has shipped this as both a plain string and a { text } object.
-      const sub = typeof h?.subtitle === "string" ? h.subtitle : h?.subtitle?.text;
+      const sub = localizedStr(h?.body) ?? localizedStr(h?.subtitle);
       return sub ? `${title}: ${sub}` : title;
     })
     .filter(Boolean);


### PR DESCRIPTION
Follow-up to #42 — my mistake there, and it left `airbnb_listing_details` returning no highlights at all.

#42 restored the amenities and highlights sections by reading them out of `pdpPresentation` after Airbnb moved both to client-side rendering. The amenities half works. The highlights half doesn't: `extractHighlights` reads `title` / `subtitle` from each `pdpPresentation.highlights[]` item, but Airbnb ships those as `headline` / `body`, each wrapped in a `LocalizedContent` object:

```json
{
  "__typename": "ListingPdpHighlight",
  "type": "LISTING_GUEST_FAVORITE",
  "headline": { "__typename": "LocalizedContent", "localizedContent": "Top 10% of homes" },
  "body": { "__typename": "LocalizedContent", "localizedContent": "This home is highly ranked based on ratings, reviews, and reliability." }
}
```

Because no item has a `title`, every entry is filtered out and `extractHighlights` returns `null`, so the `HIGHLIGHTS_DEFAULT` section is omitted from the response entirely. The call still succeeds, so consumers can't tell the difference between "this listing has no highlights" and "the extractor no longer matches the payload." That silence is why #42 looked like it worked.

The tests added in #42 used fixtures I wrote from the old field names, so they passed against a shape the live API doesn't serve. The fixture in this PR is copied from a real payload instead, `__typename` fields included.

### Verification

Checked against 20+ live listings spanning entire homes, private rooms, hotels and a hostel. Every one used `headline`/`body`; none used `title`/`subtitle`. Before this change all of them returned `null`.

Example (listing `53610715`) — before: `null`. After:

```json
{"highlights": [
  "Top 10% of homes: This home is highly ranked based on ratings, reviews, and reliability.",
  "In Rhododendron, near Mt. Hood: At the base of Mt. Hood, ...",
  "Private hot tub in the woods: A private hot tub ...",
  "Clean, cozy, and well-equipped: Guests praise ..."
]}
```

### The change

A small `localizedStr` helper normalizes a localized field across every shape seen so far — a plain string, `{ localizedContent }`, or `{ text }` — and it is applied to both sides of the pair. `headline`/`body` take precedence, with `title`/`subtitle` kept as a fallback so older payloads (and the existing tests) behave exactly as before. Non-string values are rejected rather than interpolated, since an object would otherwise render as `"[object Object]"`, and an empty value is treated as missing so the legacy key still gets its turn.

Output shape is unchanged: `{ highlights: string[] }`, or `null` when nothing maps.

### Tests

`npm test`: **31 pass, 0 fail.**

New coverage: the nested `LocalizedContent` shape (fixture taken from a real payload), the legacy `title`/`subtitle` shape, `{ text }` bodies, non-string values, empty-value fallback to the legacy key, items missing every title key, and a guard asserting output elements are always plain strings containing no `__typename`.

Reverting `extractHighlights` to the previous `title`-only logic (without rebuilding) fails 5 of the new tests on assertions — `expected highlights, got null` and deep-equal mismatches — rather than crashing at import, so the tests fail with the symptom under test.
