### PR TITLE
fix: detect Airbnb country-domain handoff and allow overriding the domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,13 @@ The extension provides the following user-configurable options:
 - **Description**: Skip the Photon/Nominatim geocoding step and let Airbnb resolve the location string on its own. Enabling this restores the pre-PR behavior — every search goes only to `airbnb.com`, no third-party calls.
 - **Recommendation**: Keep disabled unless you specifically need zero third-party outbound traffic. With it enabled, non-US searches could return incorrect results. See [External Services](#external-services).
 
+### Airbnb domain
+- **Type**: String
+- **Environment variable**: `AIRBNB_BASE_URL`
+- **Default**: `https://www.airbnb.com`
+- **Description**: The Airbnb domain to query. Airbnb runs a per-country domain (`airbnb.co.uk`, `airbnb.fr`, …) and hands requests off to the one matching your request origin, so from some regions `www.airbnb.com` never returns a page the server can parse. Point this at your country domain to query it directly.
+- **Recommendation**: Leave unset unless searches fail with a domain-handoff error. See [Country domains](#country-domains).
+
 ## Tools
 
 ### `airbnb_search`
@@ -200,9 +207,31 @@ Each search sends only the `location` string from the request to the geocoder �
 
 If a geocoder is unreachable or returns no result, the server falls back to sending the location string to Airbnb directly, exactly as it did before — so the worst case for an outage is that international searches degrade to the previous (broken) behavior, not that the search fails entirely.
 
+### Country domains
+
+Airbnb runs a separate domain per country (`airbnb.co.uk`, `airbnb.fr`, …) and hands requests off to the one matching the request origin. When that happens, `www.airbnb.com` does not return the page you asked for — it returns a ~1KB stub that POSTs to `/v2/domain_switch/handoff` via JavaScript:
+
+```html
+<body onload="document.forms[0].submit()">
+<form method="POST" action="https://www.airbnb.co.uk/v2/domain_switch/handoff">
+```
+
+It arrives as HTTP 200 rather than a 3xx, so no HTTP client follows it, and it contains none of the data the server parses. Requesting the same path on the country domain returns the full page normally.
+
+The server detects this stub and reports it explicitly, naming the domain Airbnb wants to use:
+
+```
+Airbnb handed this request off to its www.airbnb.co.uk country domain instead of
+serving <url>, so there was no page to parse. Set
+AIRBNB_BASE_URL=https://www.airbnb.co.uk to query that domain directly.
+```
+
+Setting [`AIRBNB_BASE_URL`](#airbnb-domain) resolves it for both `airbnb_search` and `airbnb_listing_details`. The default is unchanged, so this only affects setups that hit the handoff.
+
 ### Error Handling
 - Comprehensive error logging with timestamps
 - Graceful degradation when Airbnb's page structure changes
+- Country-domain handoffs reported distinctly, rather than as a page-structure change
 - Timeout protection for network requests
 - Detailed error messages for troubleshooting
 
@@ -244,16 +273,17 @@ npm run watch
 ### Testing
 
 ```bash
-# Build, then run both suites
+# Build, then run all three suites
 npm test
 ```
 
-`npm test` drives the built server over stdio and calls the tools for real:
+`npm test` runs one offline unit suite, then drives the built server over stdio and calls the tools for real:
 
+- `test-domain-handoff.js` — country-domain handoff detection against a captured stub, including the cases that must *not* be treated as a handoff. No network required
 - `test-extension.js` — MCP handshake, tool listing, a search, listing details, and the geocoding paths (Photon, Nominatim fallback)
 - `test-amenities.js` — amenity extraction across several live listings, checking that amenities Airbnb strikes through never appear as ones the listing offers
 
-Both hit `airbnb.com` and the geocoders over the network, so they need connectivity and can fail if Airbnb changes its page structure — that's the point of them, but it also means they aren't suitable as an unattended CI gate.
+The latter two hit `airbnb.com` and the geocoders over the network, so they need connectivity and can fail if Airbnb changes its page structure — that's the point of them, but it also means they aren't suitable as an unattended CI gate. They also assume `airbnb.com` serves you a parseable page; from a region where Airbnb hands off to a country domain, set `AIRBNB_BASE_URL` before running them. `test-domain-handoff.js` is offline and deterministic, so it is safe in CI.
 
 The server can also be run directly:
 
@@ -263,6 +293,9 @@ node dist/index.js
 
 # Run with robots.txt ignored (for testing)
 node dist/index.js --ignore-robots-txt
+
+# Run against a country domain (see Country domains)
+AIRBNB_BASE_URL=https://www.airbnb.co.uk node dist/index.js
 ```
 
 ## Legal and Ethical Considerations

--- a/index.ts
+++ b/index.ts
@@ -11,7 +11,7 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 import fetch from "node-fetch";
 import * as cheerio from "cheerio";
-import { cleanObject, flattenArraysInObject, pickBySchema, diagnoseJsonPath, findPdpPresentation, extractAmenities, extractHighlights, keyAmenityGroups } from "./util.js";
+import { cleanObject, flattenArraysInObject, pickBySchema, diagnoseJsonPath, findPdpPresentation, extractAmenities, extractHighlights, keyAmenityGroups, detectDomainHandoff, normalizeBaseUrl, DEFAULT_BASE_URL } from "./util.js";
 import robotsParser from "robots-parser";
 import { readFileSync } from 'fs';
 import { fileURLToPath } from 'url';
@@ -147,7 +147,26 @@ const AIRBNB_TOOLS = [
 
 // Utility functions
 const USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
-const BASE_URL = "https://www.airbnb.com";
+// Airbnb serves a per-country domain and hands off to it based on request origin,
+// so www.airbnb.com never returns a parseable page from some regions. Set
+// AIRBNB_BASE_URL to a country domain (e.g. https://www.airbnb.co.uk) to query it
+// directly. Applies to robots.txt, search and listing requests alike.
+const BASE_URL = (() => {
+  const configured = process.env.AIRBNB_BASE_URL;
+  if (!configured || !configured.trim()) return DEFAULT_BASE_URL;
+
+  const normalized = normalizeBaseUrl(configured);
+  if (normalized) return normalized;
+
+  // Fall back rather than refusing to start, but say why: a silent fallback here
+  // would look identical to the bug AIRBNB_BASE_URL exists to work around.
+  log('error', 'Ignoring invalid AIRBNB_BASE_URL, falling back to the default domain', {
+    provided: configured,
+    expected: 'an absolute http(s) URL, e.g. https://www.airbnb.co.uk',
+    using: DEFAULT_BASE_URL
+  });
+  return DEFAULT_BASE_URL;
+})();
 
 // Geocode location using Photon (fast, no rate limits) with Nominatim fallback.
 // This bypasses Airbnb's broken server-side geocoding for non-US locations.
@@ -398,6 +417,26 @@ async function fetchWithUserAgent(url: string, timeout: number = 30000) {
   }
 }
 
+// Airbnb answers with a country-domain handoff stub instead of the page when the
+// configured domain doesn't match the request origin. Detect it and say so, rather
+// than letting the parsers report it as an Airbnb page-structure change.
+function assertNotDomainHandoff(html: string, url: string) {
+  const target = detectDomainHandoff(html);
+  if (!target || target === BASE_URL) return;
+
+  log('warn', 'Airbnb served a country-domain handoff page instead of content', {
+    requested: BASE_URL,
+    handoffTarget: target,
+    url
+  });
+
+  throw new Error(
+    `Airbnb handed this request off to its ${new URL(target).host} country domain ` +
+    `instead of serving ${url}, so there was no page to parse. ` +
+    `Set AIRBNB_BASE_URL=${target} to query that domain directly.`
+  );
+}
+
 // API handlers
 async function handleAirbnbSearch(params: any) {
   const {
@@ -542,6 +581,7 @@ async function handleAirbnbSearch(params: any) {
     
     const response = await fetchWithUserAgent(searchUrl.toString());
     const html = await response.text();
+    assertNotDomainHandoff(html, searchUrl.toString());
     const $ = cheerio.load(html);
     
     let staysSearchResults: any = {};
@@ -724,6 +764,7 @@ async function handleAirbnbListingDetails(params: any) {
     
     const response = await fetchWithUserAgent(listingUrl.toString());
     const html = await response.text();
+    assertNotDomainHandoff(html, listingUrl.toString());
     const $ = cheerio.load(html);
     
     // Always an array. A consumer doing details.find(...) should never meet an object.
@@ -881,6 +922,7 @@ function log(level: 'info' | 'warn' | 'error', message: string, data?: any) {
 
 log('info', 'Airbnb MCP Server starting', {
   version: VERSION,
+  baseUrl: BASE_URL,
   ignoreRobotsTxt: IGNORE_ROBOTS_TXT,
   disableGeocoding: DISABLE_GEOCODING,
   nodeVersion: process.version,

--- a/manifest.json
+++ b/manifest.json
@@ -35,7 +35,8 @@
       "env": {
         "NODE_ENV": "production",
         "IGNORE_ROBOTS_TXT": "${user_config.ignore_robots_txt}",
-        "DISABLE_GEOCODING": "${user_config.disable_geocoding}"
+        "DISABLE_GEOCODING": "${user_config.disable_geocoding}",
+        "AIRBNB_BASE_URL": "${user_config.airbnb_base_url}"
       }
     }
   },
@@ -75,6 +76,13 @@
       "title": "Disable third-party geocoding",
       "description": "Skip the Photon/Nominatim geocoding step and let Airbnb resolve location strings on its own. Eliminates third-party outbound calls but causes non-US searches (e.g. 'Paris, France') to return wrong results.",
       "default": false,
+      "required": false
+    },
+    "airbnb_base_url": {
+      "type": "string",
+      "title": "Airbnb domain",
+      "description": "Airbnb domain to query. Leave empty to use https://www.airbnb.com. Set a country domain (e.g. https://www.airbnb.co.uk) if searches fail because Airbnb hands your requests off to a country domain.",
+      "default": "",
       "required": false
     }
   }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "prepare": "npm run build",
     "version": "node sync-version.js && git add manifest.json",
     "pretest": "npm run build",
-    "test": "node test-extension.js && node test-amenities.js",
+    "test": "node test-domain-handoff.js && node test-extension.js && node test-amenities.js",
     "watch": "tsc --watch",
     "sync-version": "node sync-version.js"
   },

--- a/test-domain-handoff.js
+++ b/test-domain-handoff.js
@@ -1,0 +1,97 @@
+// Unit: country-domain handoff detection and AIRBNB_BASE_URL normalization.
+// Offline by design — no network, so it stays reliable as a regression guard.
+import { detectDomainHandoff, normalizeBaseUrl } from "./dist/util.js";
+
+// Captured verbatim from https://www.airbnb.com/s/Lisbon--Portugal/homes from a UK
+// IP (HTTP 200, 964 bytes). The payload value is truncated; nothing reads it.
+const HANDOFF_STUB = `<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"><title>Redirecting to www.airbnb.co.uk</title></head>
+<body onload="document.forms[0].submit()">
+<form method="POST" action="https://www.airbnb.co.uk/v2/domain_switch/handoff">
+<input type="hidden" name="version" value="1">
+<input type="hidden" name="payload" value="eyJjb29raWVzIjp7ImJldiI6IjE3ODYzOTM2NDdf">
+<noscript><button type="submit">Redirecting to www.airbnb.co.uk</button></noscript>
+</form>
+</body>
+</html>`;
+
+const CASES = [
+  {
+    name: "captured .co.uk handoff stub",
+    html: HANDOFF_STUB,
+    expect: "https://www.airbnb.co.uk",
+  },
+  {
+    name: "handoff to a different country domain",
+    html: HANDOFF_STUB.replace(/airbnb\.co\.uk/g, "airbnb.fr"),
+    expect: "https://www.airbnb.fr",
+  },
+  {
+    name: "real page is not a handoff",
+    html: `<!DOCTYPE html><html><body><script id="data-deferred-state-0">{"niobeClientData":[]}</script></body></html>`,
+    expect: null,
+  },
+  {
+    name: "empty response",
+    html: "",
+    expect: null,
+  },
+  {
+    // Guards the size bail-out: a full page mentioning the path must not be
+    // mistaken for a stub, or a working search would start failing.
+    name: "large page mentioning the handoff path",
+    html: `<form action="https://www.airbnb.co.uk/v2/domain_switch/handoff">` + "x".repeat(9000),
+    expect: null,
+  },
+  {
+    name: "form without the handoff action",
+    html: `<form method="POST" action="https://www.airbnb.co.uk/v2/login"></form>`,
+    expect: null,
+  },
+  {
+    name: "non-string input",
+    html: undefined,
+    expect: null,
+  },
+];
+
+const BASE_URL_CASES = [
+  { name: "country domain", input: "https://www.airbnb.co.uk", expect: "https://www.airbnb.co.uk" },
+  { name: "trailing slash is stripped", input: "https://www.airbnb.co.uk/", expect: "https://www.airbnb.co.uk" },
+  { name: "stray path is dropped", input: "https://www.airbnb.co.uk/homes", expect: "https://www.airbnb.co.uk" },
+  { name: "surrounding whitespace", input: "  https://www.airbnb.fr  ", expect: "https://www.airbnb.fr" },
+  { name: "explicit port is kept", input: "http://localhost:8080", expect: "http://localhost:8080" },
+  { name: "missing scheme is rejected", input: "www.airbnb.co.uk", expect: null },
+  { name: "non-http scheme is rejected", input: "ftp://www.airbnb.co.uk", expect: null },
+  { name: "empty string falls through to default", input: "", expect: null },
+  { name: "whitespace only falls through to default", input: "   ", expect: null },
+  { name: "undefined falls through to default", input: undefined, expect: null },
+];
+
+let failures = 0;
+
+console.log("detectDomainHandoff:");
+for (const c of CASES) {
+  const got = detectDomainHandoff(c.html);
+  if (got !== c.expect) {
+    console.log(`  FAIL: ${c.name} — expected ${JSON.stringify(c.expect)}, got ${JSON.stringify(got)}`);
+    failures++;
+  } else {
+    console.log(`  ok: ${c.name}`);
+  }
+}
+
+console.log("\nnormalizeBaseUrl:");
+for (const c of BASE_URL_CASES) {
+  const got = normalizeBaseUrl(c.input);
+  if (got !== c.expect) {
+    console.log(`  FAIL: ${c.name} — expected ${JSON.stringify(c.expect)}, got ${JSON.stringify(got)}`);
+    failures++;
+  } else {
+    console.log(`  ok: ${c.name}`);
+  }
+}
+
+console.log(failures ? `\n${failures} FAILURE(S)` : "\nall cases passed");
+process.exit(failures ? 1 : 0);

--- a/util.ts
+++ b/util.ts
@@ -175,6 +175,58 @@ export function keyAmenityGroups(section: any): any {
   return { ...section, seeAllAmenitiesGroups: keyed };
 }
 
+export const DEFAULT_BASE_URL = "https://www.airbnb.com";
+
+/**
+ * Normalize a configured Airbnb domain to a bare origin, so that a trailing slash
+ * or a stray path can't produce URLs like "https://www.airbnb.co.uk//s/...".
+ * Returns null when the value can't be used as a base URL, letting the caller
+ * report it and fall back to the default rather than failing at request time.
+ */
+export function normalizeBaseUrl(value: string | undefined | null): string | null {
+  const trimmed = typeof value === "string" ? value.trim() : "";
+  if (!trimmed) return null;
+
+  try {
+    const url = new URL(trimmed);
+    // A scheme-less value like "www.airbnb.co.uk" parses as the "www.airbnb.co.uk:"
+    // protocol rather than failing, so check the protocol explicitly.
+    if (url.protocol !== "https:" && url.protocol !== "http:") return null;
+    return url.origin;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Airbnb runs a per-country domain (airbnb.co.uk, airbnb.fr, ...) and hands off to
+ * the one matching the request origin. When it does, the response is not the page
+ * we asked for: it's a ~1KB stub that POSTs a payload to /v2/domain_switch/handoff
+ * via JS. It arrives as HTTP 200 rather than a 3xx, so no HTTP client follows it,
+ * and it contains none of the data the parsers look for — which surfaces as a
+ * misleading "page structure may have changed" error.
+ *
+ * Returns the origin Airbnb wants to serve instead (e.g. "https://www.airbnb.co.uk"),
+ * or null if this isn't a handoff stub.
+ */
+export function detectDomainHandoff(html: string): string | null {
+  // The stub is ~1KB; a real search or listing page is ~1MB. Bailing early keeps
+  // the regex off megabyte-sized pages and avoids matching a page that merely
+  // mentions the handoff path.
+  if (typeof html !== "string" || html.length > 8192) return null;
+
+  const match = html.match(
+    /<form[^>]+action="(https?:\/\/[^"]*\/v2\/domain_switch\/handoff)"/i
+  );
+  if (!match) return null;
+
+  try {
+    return new URL(match[1]).origin;
+  } catch {
+    return null;
+  }
+}
+
 export function extractHighlights(pdp: any): any | null {
   const highlights = pdp?.highlights;
   if (!Array.isArray(highlights) || highlights.length === 0) return null;


### PR DESCRIPTION
Fixes #60.

## Problem

Airbnb runs a per-country domain (`airbnb.co.uk`, `airbnb.fr`, …) and hands requests off to the one matching the request origin. When it does, `www.airbnb.com` does not return the requested page — it returns a ~1KB stub that POSTs to `/v2/domain_switch/handoff` via JavaScript:

```html
<body onload="document.forms[0].submit()">
<form method="POST" action="https://www.airbnb.co.uk/v2/domain_switch/handoff">
```

It arrives as **HTTP 200, not a 3xx**, so no HTTP client follows it, and it contains none of the data the parsers look for.

`BASE_URL` was hardcoded to `https://www.airbnb.com` with no way to change it, so from an affected region **both tools failed unconditionally**:

```json
{
  "error": "Failed to parse search results from Airbnb. The page structure may have changed.",
  "details": "Could not find data script element - page structure may have changed"
}
```

That message points at scraper rot rather than the redirect that actually happened, which is a slow thing to diagnose. Measured from a UK IP, same path, same geocoded bbox, same user-agent:

| URL | Status | Size | `data-deferred-state` |
|---|---|---|---|
| `www.airbnb.com/s/Lisbon--Portugal/homes?…` | 200 | 964 B | absent |
| `www.airbnb.co.uk/s/Lisbon--Portugal/homes?…` | 200 | 946 KB | present |

Replaying the `bev` / `everest_cookie` values from the handoff payload back to `www.airbnb.com` still returns the stub, so this is decided by request origin and can't be cookied around. `DISABLE_GEOCODING` is unrelated — geocoding resolves the right bbox; the failure is downstream of it.

## Changes

- **`AIRBNB_BASE_URL`** — `BASE_URL` now honours it and defaults to `https://www.airbnb.com`, so existing behaviour is unchanged. It applies to robots.txt, search and listing requests alike. Values are normalized to an origin, so a trailing slash can't yield `https://host//s/...`; a value that can't be used (missing scheme, `ftp://`) is logged and ignored rather than failing later at request time.
- **Handoff detection** — both handlers check for the stub and report what actually happened:
  ```
  Airbnb handed this request off to its www.airbnb.co.uk country domain instead of
  serving <url>, so there was no page to parse. Set
  AIRBNB_BASE_URL=https://www.airbnb.co.uk to query that domain directly.
  ```
- **Startup log** now includes the effective `baseUrl` alongside `ignoreRobotsTxt` / `disableGeocoding`.
- **`manifest.json`** exposes an "Airbnb domain" string field, so MCPB hosts get it without editing env vars by hand.
- **README** — documented under Configuration, plus a "Country domains" section explaining the mechanism.

The detector bails out above 8KB. A real page is ~1MB, so this keeps the regex off large bodies and stops a page that merely *mentions* the handoff path from being misread as a redirect.

## Testing

New `test-domain-handoff.js` (wired into `npm test`) covers detection against a stub captured verbatim from the failing request, the cases that must **not** be treated as a handoff (real page, empty body, full-size page mentioning the path, non-handoff form, non-string input), and base URL normalization — 17 cases. It needs no network, so unlike the existing two suites it's safe as a CI gate.

```
detectDomainHandoff:   7 ok
normalizeBaseUrl:     10 ok
all cases passed
```

End-to-end against the built server over stdio from a UK IP:

| Scenario | Before | After |
|---|---|---|
| `airbnb_search`, default domain | "page structure may have changed" | actionable handoff error naming `.co.uk` + the env var |
| `airbnb_search`, `AIRBNB_BASE_URL=https://www.airbnb.co.uk` | same failure | listings returned, `rooms/` URLs on the configured domain |
| `airbnb_listing_details`, same override | same failure | amenities, house rules and policies returned |

`test-extension.js` and `test-amenities.js` assume `airbnb.com` serves a parseable page, so from an affected region they need `AIRBNB_BASE_URL` set to pass; I've noted that in the README rather than changing them, since they're deliberately live-network tests. I couldn't run them unmodified against `airbnb.com` from here — that's precisely the bug — but both pass with the override set.

## Notes for reviewers

- Default behaviour is unchanged: with `AIRBNB_BASE_URL` unset, the only difference is a clearer error when Airbnb hands the request off, and one extra key in the startup log.
- I deliberately did **not** auto-retry on the country domain, though it would make this work with zero configuration. Following the handoff means requesting a different host than the one whose `robots.txt` was fetched and checked at startup, and `robotsTxtContent` / `isPathAllowed` are currently single-host. Doing it properly means making robots state per-host, which felt like it deserved its own PR rather than riding along with a bug fix. Happy to write it if you'd like it in this one.
- Alternatively, if you'd rather not have the env var at all and prefer only the improved error message, I can trim the PR to that.
